### PR TITLE
docs: record the v1.1.0 cutover

### DIFF
--- a/docs/engineering/PENDING_TASKS.md
+++ b/docs/engineering/PENDING_TASKS.md
@@ -58,19 +58,35 @@ all green, checksums verified, packaged macOS app launched).
    `main/version.py` reads `1.1.0`, every running v1.0.1 client announces it within
    three seconds of its next launch.
 
+### How it actually went
+
+All seven steps completed on 2026-08-09, in that order. Two things worth carrying to
+the next release:
+
+- **`gh release create` with 198 MB of assets did not finish inside ten minutes.**
+  `gh` creates the release as a *draft*, uploads, then publishes, so the interruption
+  left a draft with only the three small sidecars and nothing public — a good failure
+  mode. The zips were uploaded to that draft separately and the draft was published
+  once all six assets were present. Upload the large assets in their own step.
+- **The release notes linked to `blob/main/UPGRADE.md`, which did not exist on `main`
+  until step 7.** Anyone opening the Release page between steps 4 and 7 would have hit
+  a 404. The links now point at `blob/v1.1.0/`, which is also the correct habit: a
+  release should describe fixed content, not a branch that moves after publication.
+
 ### Known gap in the tooling
 
 Neither workflow publishes a GitHub Release; both end at `actions/upload-artifact`
-with 14-day retention. Steps 3–4 are therefore manual. Worth automating before the
-second release, not before the first.
+with 14-day retention. Steps 3–4 were therefore manual. Worth automating before the
+second release.
 
-### Why this is paused
+### Why it was paused
 
-The release would ship the defects catalogued in
+The release would have shipped the defects catalogued in
 [CODE_DEFECT_REMEDIATION_PLAN.md](CODE_DEFECT_REMEDIATION_PLAN.md), two of which
-block the owner's own stated goal of building a multi-year daily and symbol-wise
-database. Publishing first would mean notifying every existing user to upgrade to a
-build that cannot complete a historical backfill.
+blocked the owner's own stated goal of building a multi-year daily and symbol-wise
+database. Publishing first would have meant notifying every existing user to upgrade
+to a build that could not complete a historical backfill. Phases 1–3 closed those
+defects first, which is what made this release publishable.
 
 ## 1. BSE SME/Startup classification and symbol naming
 

--- a/docs/engineering/RELEASE_IMPLEMENTATION_PLAN.md
+++ b/docs/engineering/RELEASE_IMPLEMENTATION_PLAN.md
@@ -150,15 +150,18 @@ Open decision, deliberately not taken unilaterally:
 
 ## Stage 2 — Cutover
 
-Execute in order. Step 2.3 is the point of no return.
+**Completed 2026-08-09.** Executed in order; step 2.3 was the point of no return.
 
-- [ ] **2.1** Re-run all gates at the release commit in both environments
-- [ ] **2.2** Publish the Release (Stage 1.3) — *still reversible: delete release + tag*
-- [ ] **2.3** Mark PR #10 ready and **merge with a merge commit** (not squash, not
+- [x] **2.1** Re-run all gates at the release commit in both environments —
+      398 tests on Python 3.10 and 3.13, coverage 77.2%, Ruff, mypy, `--smoke-gui`
+- [x] **2.2** Publish the Release (Stage 1.3) — tag `v1.1.0` at `059f497`, three
+      platform assets plus sidecars, every digest verified from the published page
+- [x] **2.3** Mark PR #10 ready and **merge with a merge commit** (not squash, not
       rebase — GitHub reports `rebaseable: false`, and the branch carries two
       multi-parent commits including the history-preserving import `8b338e3`)
-      → **this publishes the notification to every v1.0.1 user**
-- [ ] **2.4** Watch CI green on `main`
+      → merge commit `ed06dc8`; `main/version.py` now reads `1.1.0`, and the released
+      commit is an ancestor of `main`, so the tag describes code that is on `main`
+- [x] **2.4** Watch CI green on `main`
 - [ ] **2.5** Watch issues for 48 hours
 
 Rollback after 2.3: do **not** force-push `main`. Restore from `archive/pyqt6-v1.0.1` in


### PR DESCRIPTION
Documentation only, no source changes.

- `RELEASE_IMPLEMENTATION_PLAN.md` Stage 2 ticked with the real outcome: merge commit `ed06dc8`, CI green on `main`, and the released commit confirmed to be an ancestor of `main`.
- `PENDING_TASKS.md` §0 records two findings for the next release: the 198 MB upload does not fit in one `gh release create`, and release notes must link to the tag rather than to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)