### PR TITLE
docs: stop sending users to builds that cannot download anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 > ### Upgrading from v1.0.1? Read **[UPGRADE.md](UPGRADE.md)** first.
 > v1.1.0 replaced PyQt6 with PySide6 and requires Python 3.10 or newer. Copying these
 > files over an existing v1.0.1 install **without** running
-> `pip install -r requirements.txt` will stop the app from starting. Prebuilt
-> applications that need no setup are on the
-> [releases page](https://github.com/pparesh25/NSE_BSE_Downloader/releases/latest).
+> `pip install -r requirements.txt` will stop the app from starting.
+>
+> **The prebuilt v1.1.0 applications have been withdrawn**, so no release is published
+> at the moment. They carried no certificate store and could not download anything;
+> running from source is not affected. Install from source with the steps below until a
+> corrected build is published.
 
 A desktop downloader that turns legacy and current NSE/BSE reports into one stable daily-file format.
 
@@ -58,8 +61,9 @@ Version 1.1 keeps the existing `~/NSE_BSE_Data/` data root and
 `~/.nse_bse_downloader/` preference directory. Existing seven-column daily files
 remain readable and are not rewritten merely by launching the application. A date
 downloaded again is published under the current stable nine-column EQ/SME/FO
-contract. Back up important user data before a major upgrade and use the official
-GitHub Release assets rather than an archive from a mutable branch.
+contract. Back up important user data before a major upgrade. While no release is
+published, install from the immutable `v1.1.0` tag rather than an archive from a
+mutable branch.
 
 ## Nuitka packaging and release trust
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,35 +4,25 @@
 is the one you need.** The download you just received is application source code, not a
 ready-to-run installer, and v1.1.0 needs a different set of libraries than v1.0.1 did.
 
-Two ways forward. Pick one.
+There were two ways forward. **Option A is unavailable right now**, so Option B is the
+one to follow.
 
 ---
 
-## Option A — Download a prebuilt application (easiest)
+## Option A — Download a prebuilt application (withdrawn)
 
-Go to the releases page and download the file for your system:
+**The prebuilt v1.1.0 applications have been withdrawn, and no release is published at
+the moment.** The releases page is empty on purpose; there is nothing there to
+download.
 
-**https://github.com/pparesh25/NSE_BSE_Downloader/releases/latest**
+They were withdrawn because they could not download market data at all. The packaged
+application carried its own copy of OpenSSL but no certificate store, so every HTTPS
+request to NSE and BSE failed certificate verification, and the app reported an "SSL
+certificate issue" for every date. The exchanges were fine; the build was not.
 
-| Your system | File to download |
-|---|---|
-| Windows 10/11, 64-bit | `NSE_BSE_Downloader-1.1.0-windows-x64.zip` |
-| Mac with Apple Silicon (M1/M2/M3/M4) | `NSE_BSE_Downloader-1.1.0-darwin-arm64.zip` |
-| Linux, 64-bit | `NSE_BSE_Downloader-1.1.0-linux-x64.zip` |
-
-Each file has a matching `.sha256` file next to it if you want to verify the download.
-
-Unzip it and run it. Nothing else to install — Python and all libraries are bundled.
-
-> **Intel Mac users:** there is no prebuilt build for Intel Macs. Use Option B.
-
-> **macOS first launch:** the app is not signed with an Apple Developer certificate, so
-> macOS will refuse to open it on the first try. This is expected. **Right-click** (or
-> Control-click) the app icon, choose **Open**, then click **Open** in the dialog. You
-> only need to do this once.
-
-> **Windows first launch:** SmartScreen may show "Windows protected your PC" for the same
-> reason. Click **More info** → **Run anyway**.
+**Running from source is not affected by this**, because it uses the certificates your
+own Python installation already trusts. Use Option B. This section will return, with
+the file names and first-launch instructions, once a corrected build is published.
 
 ---
 
@@ -85,10 +75,10 @@ Other errors and what they mean:
 ### Older systems
 
 PySide6 requires macOS 13 (Ventura) or newer, and a reasonably recent Linux. If `pip`
-refuses to install it, your system is below that floor. v1.0.1 remains available and
-functional:
+refuses to install it, your system is below that floor. The v1.0.1 source remains
+available and functional, under "Source code" on its tag page:
 
-**https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/1.0.1**
+**https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/v1.0.1**
 
 ---
 
@@ -142,8 +132,8 @@ date range shown before clicking Start, and narrow it if it is larger than you e
 
 ## Going back to v1.0.1
 
-v1.0.1 still runs and still reads your data folder. Download it from the
-[1.0.1 release](https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/1.0.1).
+v1.0.1 still runs and still reads your data folder. Download its source from the
+[v1.0.1 tag](https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/v1.0.1).
 
 Be aware this is not a clean round trip: 9-column files written by v1.1.0 stay
 9-column, and v1.0.1 does not understand the `.state` folder v1.1.0 creates. It will


### PR DESCRIPTION
## Why

The v1.1.0 prebuilt applications were withdrawn and the GitHub Release deleted with them, but `README.md` and `UPGRADE.md` still advertised the three ZIPs. An installed v1.0.1 client still announces the update, so its user was being sent to an empty releases page with no explanation.

## Root cause of the withdrawn builds, reproduced

Against the withdrawn `darwin-arm64` build (`BUILD-METADATA.json` `git_commit` `059f497`):

- The bundle ships its own `libssl.3.dylib` / `libcrypto.3.dylib`, compiled with `OPENSSLDIR = /Library/Frameworks/Python.framework/Versions/3.13/etc/openssl` — the runner's python.org framework path, absent on an end user's machine.
- No `cacert.pem` is bundled and `certifi` is not a dependency, so OpenSSL starts with zero trusted roots.
- Run as shipped, the packaged app fails its own update check with `CERTIFICATE_VERIFY_FAILED ... unable to get local issuer certificate`.
- The same binary with `SSL_CERT_FILE=/etc/ssl/cert.pem` completes it silently.

That explains the reported download log exactly: every date reported an SSL certificate issue, and the host circuit breaker then opened. The classifier treating a certificate failure as terminal is correct; the exchanges were never the problem. Source installs are unaffected — they use the certificates the user's own Python trusts.

The packaging fix itself is not in this PR.

## Changes

- `UPGRADE.md` Option A marked **withdrawn** rather than deleted, with the reason and a clear pointer to Option B. It will be restored with the file names and first-launch instructions once a corrected build is published.
- `README.md` header no longer promises prebuilt applications; the upgrade note points at the immutable `v1.1.0` tag instead of Release assets that no longer exist.
- Two links to `releases/tag/1.0.1` were already 404 — the tag is `v1.0.1` — and now resolve, described as the tag's source archive.

## Verification

Python 3.13: 398 passed, coverage 77.17%, `ruff` clean, `mypy` clean on 54 files, `--smoke-gui` exit 0.
Python 3.10: 398 passed, `--smoke-gui` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)