### PR TITLE
docs: record that v1.1.0 was withdrawn, and why

### DIFF
--- a/docs/engineering/PENDING_TASKS.md
+++ b/docs/engineering/PENDING_TASKS.md
@@ -1,7 +1,7 @@
 # Pending engineering tasks
 
-Last reviewed: 2026-08-06 (Asia/Kolkata)
-Repository branch at review: `codex/pyside6-port-v1.1.0`
+Last reviewed: 2026-08-14 (Asia/Kolkata)
+Repository branch at review: `main`
 
 ## Working convention
 
@@ -14,17 +14,22 @@ This file is the central index for approved but incomplete engineering work. Det
 research and evidence files remain authoritative references, but every deferred topic
 must also be recorded here so it is not lost between phases.
 
-## 0. v1.1.0 release publication — published 2026-08-09
+## 0. v1.1.0 release publication — published 2026-08-09, withdrawn 2026-08-14
 
-Status: **Done.** Paused on 2026-08-06 so that code-level defect remediation could go
-first; resumed once Phase 3 of
+Status: **Withdrawn.** Paused on 2026-08-06 so that code-level defect remediation could
+go first; resumed once Phase 3 of
 [CODE_DEFECT_REMEDIATION_PLAN.md](CODE_DEFECT_REMEDIATION_PLAN.md) closed, which
 removed every defect the pause existed to avoid shipping.
 
-Published from tag `v1.1.0` at commit `059f497`:
-<https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/v1.1.0>. Asset digests
-and the verification performed on them are in
-[RELEASE_BUILD_EVIDENCE.md](RELEASE_BUILD_EVIDENCE.md).
+Published from tag `v1.1.0` at commit `059f497`, then unpublished on 2026-08-14 with
+all six assets: the shipped builds carried no certificate store and could not download
+anything. The defect and its reproduction are in
+[RELEASE_BUILD_EVIDENCE.md](RELEASE_BUILD_EVIDENCE.md); the work to fix it is §3 below.
+The `v1.1.0` tag remains, so
+<https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/v1.1.0> still resolves to
+the tag and its source archives. `main` still reads `1.1.0`, so installed v1.0.1
+clients still announce the update; `README.md` and `UPGRADE.md` were corrected to send
+them to the source install rather than to an empty releases page.
 
 The steps below are kept as the record of how it was done, and as the template for the
 next release.
@@ -232,3 +237,43 @@ unchanged symbol-history files, reducing unnecessary publication, and evaluating
 bounded file-write improvements. The current pipeline already batches history merges
 in memory, but it must still publish thousands of individual files for a fresh
 Select-All run.
+
+## 3. Packaged builds have no certificate store
+
+Status: Root cause established and reproduced; fix not started. **Blocks any
+republication of v1.1.0 or any later release.**
+
+Detailed record: [RELEASE_BUILD_EVIDENCE.md](RELEASE_BUILD_EVIDENCE.md), "Why the
+release was withdrawn".
+
+### What is wrong
+
+The Nuitka bundle ships its own OpenSSL, compiled with an `OPENSSLDIR` that exists
+only on the build runner, and no CA bundle is included. The packaged application
+therefore starts with zero trusted roots and every HTTPS request fails certificate
+verification. `certifi` is not a dependency at all, and `http_client.py` passes
+`ssl=True`, which relies on whatever OpenSSL's compiled-in default happens to be.
+
+### Approved implementation direction
+
+- Add `certifi` to `requirements.txt` as a runtime dependency.
+- Build the TLS context from `certifi.where()` in one place, and use it for both the
+  downloader and the update checker, rather than relying on OpenSSL defaults.
+- Ensure the packaging step includes `certifi`'s data file in the bundle, and assert
+  its presence in the packaging dry run rather than discovering its absence at runtime.
+- Prefer an explicit, verifiable trust store over an `SSL_CERT_FILE` environment
+  variable set at startup: the environment variable works, but it is invisible to the
+  test suite and to anyone reading the code.
+
+### Required evidence
+
+- A test that fails without the fix: assert the connector's TLS context loads CA
+  certificates, so a future packaging change cannot silently drop them again.
+- **A compiled artifact on each platform observed completing a real HTTPS request.**
+  This is the gap that let the defect ship. Every existing check — checksums, layout,
+  provenance, Gatekeeper, `--smoke-gui` — passes on a build that cannot open a TLS
+  connection, because none of them touch the network.
+- Verify macOS, Windows and Linux separately. The macOS build is the one reproduced
+  against; Windows almost certainly shares the defect, and Linux may survive by finding
+  `/etc/ssl/certs`. Do not infer one platform from another.
+- Re-run the full gate set in both supported environments.

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -20,9 +20,9 @@ formatting alone; three of the older audits are largely in Gujarati for that rea
 | [PENDING_TASKS.md](PENDING_TASKS.md) | Central index of approved but incomplete work |
 | [CODE_DEFECT_REMEDIATION_PLAN.md](CODE_DEFECT_REMEDIATION_PLAN.md) | **Current focus.** Phased plan for the defects blocking a multi-year backfill |
 | [PROJECT_REVIEW_2026-08-06.md](PROJECT_REVIEW_2026-08-06.md) | The review those defects came from, with evidence |
-| [RELEASE_IMPLEMENTATION_PLAN.md](RELEASE_IMPLEMENTATION_PLAN.md) | Staged plan for the v1.1.0 cutover and after (paused) |
+| [RELEASE_IMPLEMENTATION_PLAN.md](RELEASE_IMPLEMENTATION_PLAN.md) | Staged plan for the v1.1.0 cutover and after |
 | [RELEASE_RUNBOOK.md](RELEASE_RUNBOOK.md) | Verified steps for branch protection, release build, signing |
-| [RELEASE_NOTES_1.1.0.md](RELEASE_NOTES_1.1.0.md) | Drafted user-facing notes for the paused release |
+| [RELEASE_NOTES_1.1.0.md](RELEASE_NOTES_1.1.0.md) | User-facing notes for v1.1.0, published then withdrawn |
 | [CANONICAL_REPOSITORY_MIGRATION.md](CANONICAL_REPOSITORY_MIGRATION.md) | Record of the PySide6 port becoming canonical here |
 
 ## Release and packaging
@@ -31,7 +31,7 @@ formatting alone; three of the older audits are largely in Gujarati for that rea
 |---|---|
 | [PACKAGING.md](PACKAGING.md) | Nuitka build, signing and fresh-user verification checklist |
 | [RELEASE_TRUST_ASSETS.md](RELEASE_TRUST_ASSETS.md) | Signing credential policy and clean-machine acceptance gate |
-| [RELEASE_BUILD_EVIDENCE.md](RELEASE_BUILD_EVIDENCE.md) | Recorded output of actual build attempts |
+| [RELEASE_BUILD_EVIDENCE.md](RELEASE_BUILD_EVIDENCE.md) | What v1.1.0 actually shipped, and why it was withdrawn |
 
 ## Audits and findings
 

--- a/docs/engineering/RELEASE_BUILD_EVIDENCE.md
+++ b/docs/engineering/RELEASE_BUILD_EVIDENCE.md
@@ -3,8 +3,11 @@
 Date: 2026-08-09 (Asia/Kolkata)
 Tag: `v1.1.0`
 Source commit built and published: `059f497c7716f9910ea70a2b8ea0e1d2dcb769d4`
-Release status: **published** —
-<https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/v1.1.0>
+Release status: **withdrawn 2026-08-14.** Published on 2026-08-09, then unpublished
+with all six assets after the shipped builds proved unable to download any market
+data. The `v1.1.0` tag remains; the Release does not, so
+<https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/v1.1.0> now shows the
+tag and its source archives only. See "Why the release was withdrawn" below.
 
 ## Purpose
 
@@ -37,8 +40,45 @@ Ruff, mypy, and the packaging dry run.
 | `NSE_BSE_Downloader-1.1.0-windows-x64.zip` | 48,394,086 | `660b0f1c521616778dd79c19925aa06fb0f1d4c7ff36301d614d9ef9dcebd0ab` |
 | `NSE_BSE_Downloader-1.1.0-linux-x64.zip` | 84,434,022 | `bacafebe4695861fc7c8aa519d4327212285c8a0b8f154371f1e10f061bbccc3` |
 
-Each ZIP ships with its `.sha256` sidecar in `shasum -c` format, so a user can verify
-a download without trusting this document.
+Each ZIP shipped with its `.sha256` sidecar in `shasum -c` format, so a user could
+verify a download without trusting this document. The assets are no longer
+downloadable; the digests are kept so a copy already downloaded can still be
+identified as one of these builds.
+
+## Why the release was withdrawn
+
+The three published applications could not download market data at all. Every date in
+a run failed, the log reported an SSL certificate issue for each one, and the host
+circuit breaker then opened and skipped the rest.
+
+Reproduced on 2026-08-14 against the withdrawn `darwin-arm64` asset, whose
+`BUILD-METADATA.json` records `git_commit 059f497` — the tagged commit in this record:
+
+- The bundle ships its own `libssl.3.dylib` and `libcrypto.3.dylib`, compiled with
+  `OPENSSLDIR = /Library/Frameworks/Python.framework/Versions/3.13/etc/openssl`. That
+  is the python.org framework path present on the build runner; it does not exist on
+  an end user's machine.
+- No `cacert.pem` is bundled anywhere in the app, and `certifi` is not a dependency,
+  so the bundled OpenSSL starts with **zero trusted roots**.
+- Run as shipped, the packaged application fails its own update check with
+  `CERTIFICATE_VERIFY_FAILED ... unable to get local issuer certificate`.
+- The same binary, with `SSL_CERT_FILE=/etc/ssl/cert.pem`, completes that check
+  silently. Nothing else changed between the two runs.
+
+Classifying a certificate failure as terminal is correct, so the downloader behaved as
+designed; the trust store was simply absent. Running from source is unaffected,
+because it uses the certificates the user's own Python installation already trusts.
+
+**Why the verification below did not catch it.** Every check in this record is
+satisfied by a build that cannot open a TLS connection. `--smoke-gui` constructs the
+GUI and exits; it makes no network request. Checksums, layout, provenance and
+Gatekeeper all describe the file, not its ability to work. The one property a user
+cares about — that it can fetch a bhavcopy — was never asserted against a compiled
+artifact on any platform.
+
+The macOS asset is the one reproduced against. The Windows build almost certainly
+carries the same defect; the Linux build may find `/etc/ssl/certs` and survive. Each
+platform must be verified separately rather than inferred from this one.
 
 ## Independent verification
 
@@ -75,13 +115,17 @@ documented for users rather than hidden.
 updater **notification-only** for every platform. It never executes a downloaded
 artifact without a checksum bound in advance.
 
-## What remains, after this release
+## What remains, before anything is published again
 
-1. Application icons for macOS, Windows and Linux.
-2. Signing credentials: Developer ID plus notarization for macOS, and a Windows
+1. **A certificate store in the packaged build**, and a check that proves it. Nothing
+   may be republished until a compiled artifact on each platform is observed to
+   complete a real HTTPS request. Tracked in
+   [PENDING_TASKS.md](PENDING_TASKS.md) §3.
+2. Application icons for macOS, Windows and Linux.
+3. Signing credentials: Developer ID plus notarization for macOS, and a Windows
    certificate if that route is chosen.
-3. A macOS Intel build, or a documented source-only route for Intel hardware.
-4. Automating the Release step itself: both workflows still end at
+4. A macOS Intel build, or a documented source-only route for Intel hardware.
+5. Automating the Release step itself: both workflows still end at
    `actions/upload-artifact`, so publishing was manual this time.
 
 ## Superseded evidence

--- a/docs/engineering/RELEASE_NOTES_1.1.0.md
+++ b/docs/engineering/RELEASE_NOTES_1.1.0.md
@@ -123,7 +123,7 @@ expect.
 ## Going back
 
 v1.0.1 still runs and still reads your data folder:
-[1.0.1 release](https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/1.0.1).
+[v1.0.1 tag](https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/v1.0.1).
 Note it is not a clean round trip — 9-column files stay 9-column, and v1.0.1 ignores the
 `.state` folder this version creates.
 


### PR DESCRIPTION
Follow-up to #12, which fixed the user-facing docs. This fixes the engineering record, which still said v1.1.0 was published and described six assets that no longer exist.

## Changes

- **`RELEASE_BUILD_EVIDENCE.md`** — status is now "withdrawn 2026-08-14". Digests are kept, so a copy already downloaded can still be identified as one of these builds. Adds the reproduction: the bundle's own `libcrypto` is compiled with `OPENSSLDIR = /Library/Frameworks/Python.framework/Versions/3.13/etc/openssl` (present on the runner, absent on a user's machine), no `cacert.pem` is bundled, `certifi` is not a dependency; the shipped binary fails its own update check with `CERTIFICATE_VERIFY_FAILED`, and the same binary with `SSL_CERT_FILE=/etc/ssl/cert.pem` completes it.
- It also records **why the verification in that same file did not catch this**: checksums, layout, provenance, Gatekeeper and `--smoke-gui` all pass on a build that cannot open a TLS connection, because none of them touch the network. That is the gap to close, not an oversight in any single step.
- **`PENDING_TASKS.md`** — §0 marked withdrawn; new **§3** for the certificate-store fix, its approved direction and the evidence it must produce, stated as blocking any republication. Review header moved to 2026-08-14 / `main`.
- **`docs/engineering/README.md`** — two index descriptions corrected ("paused release" is no longer accurate).
- **`RELEASE_NOTES_1.1.0.md`** — one `releases/tag/1.0.1` link that was already a 404 now points at the `v1.0.1` tag.

Documentation only; no source or test changes.

## Verification

Python 3.13: 398 passed, coverage 77.17%, `ruff` clean, `mypy` clean on 54 files, `--smoke-gui` exit 0.
Python 3.10: 398 passed, `--smoke-gui` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)