### PR TITLE
fix: give the packaged application certificates to verify against

### DIFF
--- a/build_nuitka_cross_platform.py
+++ b/build_nuitka_cross_platform.py
@@ -35,9 +35,14 @@ PROJECT_ROOT = Path(__file__).resolve().parent
 REQUIRED_MODULES = {
     "PySide6.QtWidgets": "PySide6",
     "aiohttp": "aiohttp",
+    "certifi": "certifi",
     "pandas": "pandas",
     "yaml": "PyYAML",
 }
+# A CA bundle is a few hundred kilobytes of PEM blocks.  Anything much smaller
+# is a stub or a truncated file, and would compile into a build that trusts
+# almost nothing while looking correctly configured.
+MINIMUM_CA_BUNDLE_BYTES = 50_000
 REQUIRED_RESOURCES = (
     Path("config.yaml"),
     Path("src/gui/resources/QR_UPI.jpeg"),
@@ -132,6 +137,32 @@ def validate_icon_resources(resources: Path) -> List[str]:
     return errors
 
 
+def certificate_bundle_errors() -> List[str]:
+    """Check that there is a real trust store to bundle into the build.
+
+    The v1.1.0 artifacts compiled and passed every other gate while carrying no
+    certificates at all, so they could not open a single HTTPS connection on a
+    user's machine.  This runs in the dry run, before a 20-minute build.
+    """
+
+    errors: List[str] = []
+    try:
+        import certifi
+    except ImportError:
+        # missing_runtime_dependencies() names the distribution to install.
+        return errors
+
+    bundle = Path(certifi.where())
+    if not bundle.is_file():
+        errors.append(f"CA certificate bundle is missing: {bundle}")
+    elif bundle.stat().st_size < MINIMUM_CA_BUNDLE_BYTES:
+        errors.append(
+            f"CA certificate bundle is implausibly small "
+            f"({bundle.stat().st_size} bytes): {bundle}"
+        )
+    return errors
+
+
 def missing_runtime_dependencies() -> List[str]:
     missing = []
     for module, distribution in REQUIRED_MODULES.items():
@@ -183,6 +214,10 @@ def get_nuitka_command(
         "--file-reference-choice=runtime",
         f"--include-data-files={project_root / 'config.yaml'}=config.yaml",
         (f"--include-data-dir={project_root / 'src/gui/resources'}=src/gui/resources"),
+        # Without this the compiled binary has no certificates to verify
+        # against, and every HTTPS request fails.  Nuitka compiles certifi's
+        # module but treats cacert.pem as data it does not need.
+        "--include-package-data=certifi",
         f"--output-dir={destination}",
         f"--output-filename={APP_NAME}",
         f"--company-name={ORGANIZATION_NAME}",
@@ -469,6 +504,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     missing = missing_runtime_dependencies()
     if missing:
         _print_errors("Missing runtime dependencies:", missing)
+        return 1
+    bundle_errors = certificate_bundle_errors()
+    if bundle_errors:
+        _print_errors("Certificate bundle validation failed:", bundle_errors)
         return 1
 
     output_dir = args.output_dir.resolve()

--- a/main.py
+++ b/main.py
@@ -108,6 +108,11 @@ Examples:
         action="store_true",
         help=argparse.SUPPRESS,
     )
+    parser.add_argument(
+        "--verify-tls",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     repair.add_argument(
         "--rebuild-exchange",
         choices=("NSE", "BSE"),
@@ -295,10 +300,53 @@ def run_gui_mode(config_path: str, *, smoke_test: bool = False):
 
 
 
+def run_tls_check() -> int:
+    """Prove this build can complete one verified HTTPS request.
+
+    Every other packaging check -- checksums, layout, provenance, Gatekeeper,
+    --smoke-gui -- is satisfied by a binary that cannot open a TLS connection,
+    which is exactly how v1.1.0 shipped without a certificate store. This is the
+    one check that touches the network, so it runs against the compiled artifact
+    during packaging rather than only against the source tree under pytest.
+    """
+
+    from src.utils.http_client import fetch_text_sync
+    from src.utils.tls import certificate_bundle_path, default_ssl_context
+
+    bundle = certificate_bundle_path()
+    authorities = len(default_ssl_context().get_ca_certs())
+    print(f"Certificate bundle: {bundle if bundle is not None else 'NONE (system default)'}")
+    print(f"Trusted certificate authorities loaded: {authorities}")
+
+    if bundle is None:
+        # A build that relies on the host's trust store is the defect itself: it
+        # works on the machine that built it and nowhere else.
+        print("TLS verification FAILED: no certificate bundle travelled with this build")
+        return 1
+    if authorities == 0:
+        print("TLS verification FAILED: the bundle loaded no certificate authorities")
+        return 1
+
+    url = "https://raw.githubusercontent.com/pparesh25/NSE_BSE_Downloader/main/version.py"
+    try:
+        # The updater's own endpoint, reached through the application's own HTTP
+        # client, so this exercises the shipped path rather than a private one.
+        fetch_text_sync(url, timeout=30)
+    except Exception as error:
+        print(f"TLS verification FAILED for {url}: {error!r}")
+        return 1
+
+    print("TLS verification passed.")
+    return 0
+
+
 def main():
     """Main entry point"""
     parser = setup_argument_parser()
     args = parser.parse_args()
+
+    if args.verify_tls:
+        return run_tls_check()
 
     # Validate config file exists
     config_path = Path(args.config)

--- a/package_release_artifact.py
+++ b/package_release_artifact.py
@@ -82,9 +82,13 @@ def smoke_test(package: Path, target_platform: str) -> None:
 
     # v1.1.0 passed every other check here and could not open a single TLS
     # connection on a user's machine, because none of them touch the network.
-    _run_smoke_command(
+    # What this proves is printed rather than discarded: a passing check that
+    # leaves no evidence is how a green tick came to mean nothing last time.
+    tls_output = _run_smoke_command(
         executable, ["--verify-tls"], package.parent, os.environ.copy()
     )
+    for line in tls_output.splitlines():
+        print(f"  [packaged] {line}")
 
     with tempfile.TemporaryDirectory(prefix="nse-bse-gui-smoke-") as directory:
         root = Path(directory)
@@ -119,7 +123,9 @@ def _run_smoke_command(
     arguments: Sequence[str],
     cwd: Path,
     environment: dict[str, str],
-) -> None:
+) -> str:
+    """Run one packaged command and return its standard output."""
+
     result = subprocess.run(
         [str(executable), *arguments],
         cwd=cwd,
@@ -130,13 +136,15 @@ def _run_smoke_command(
         timeout=180,
         check=False,
     )
+    stdout = (result.stdout or b"").decode("utf-8", errors="replace")
     if result.returncode != 0:
         stderr = result.stderr.decode("utf-8", errors="replace")[-2000:]
         command = " ".join(arguments)
         raise RuntimeError(
             f"Packaged {command} smoke test failed with "
-            f"{result.returncode}: {stderr}"
+            f"{result.returncode}: {stdout[-2000:]}{stderr}"
         )
+    return stdout
 
 
 def _iter_package_paths(package: Path) -> Iterable[Path]:

--- a/package_release_artifact.py
+++ b/package_release_artifact.py
@@ -75,10 +75,16 @@ def executable_path(package: Path, target_platform: str) -> Path:
 
 
 def smoke_test(package: Path, target_platform: str) -> None:
-    """Exercise CLI loading and an isolated real GUI startup."""
+    """Exercise CLI loading, one verified HTTPS request, and a real GUI startup."""
 
     executable = executable_path(package, target_platform)
     _run_smoke_command(executable, ["--help"], package.parent, os.environ.copy())
+
+    # v1.1.0 passed every other check here and could not open a single TLS
+    # connection on a user's machine, because none of them touch the network.
+    _run_smoke_command(
+        executable, ["--verify-tls"], package.parent, os.environ.copy()
+    )
 
     with tempfile.TemporaryDirectory(prefix="nse-bse-gui-smoke-") as directory:
         root = Path(directory)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,11 @@ pandas>=2.0.0,<3
 # Async HTTP requests
 aiohttp>=3.9.0,<4
 
+# CA certificates carried with the application.  A compiled build ships its own
+# OpenSSL, whose compile-time certificate directory does not exist on a user's
+# machine, so the trust store has to travel with us rather than be looked up.
+certifi>=2024.2.2
+
 # Configuration management
 pyyaml>=6.0,<7
 

--- a/src/services/corporate_actions.py
+++ b/src/services/corporate_actions.py
@@ -14,6 +14,7 @@ from typing import Any, Iterable, List, Optional, Tuple
 import aiohttp
 import pandas as pd
 
+from ..utils.tls import default_ssl_context
 from .canonical_data import valid_isin, valid_security_id
 from .symbol_history import SymbolHistoryStore
 from .state_store import (
@@ -326,7 +327,9 @@ class CorporateActionClient:
         }
         timeout = aiohttp.ClientTimeout(total=self.timeout)
         async with aiohttp.ClientSession(
-            timeout=timeout, headers=headers
+            timeout=timeout,
+            headers=headers,
+            connector=aiohttp.TCPConnector(ssl=default_ssl_context()),
         ) as session:
             async with session.get("https://www.nseindia.com/") as response:
                 await response.read()
@@ -358,7 +361,9 @@ class CorporateActionClient:
         }
         timeout = aiohttp.ClientTimeout(total=self.timeout)
         async with aiohttp.ClientSession(
-            timeout=timeout, headers=headers
+            timeout=timeout,
+            headers=headers,
+            connector=aiohttp.TCPConnector(ssl=default_ssl_context()),
         ) as session:
             async with session.get(
                 "https://api.bseindia.com/BseIndiaAPI/api/CorpactCSVDownload/w",

--- a/src/utils/http_client.py
+++ b/src/utils/http_client.py
@@ -13,6 +13,8 @@ from typing import Optional, Callable, Dict
 
 import aiohttp
 
+from .tls import default_ssl_context
+
 
 @dataclass
 class HTTPStatusError(Exception):
@@ -40,9 +42,10 @@ async def _single_use_session(
     headers: Optional[Dict[str, str]] = None,
 ) -> aiohttp.ClientSession:
     client_timeout = aiohttp.ClientTimeout(total=timeout) if timeout else aiohttp.ClientTimeout()
-    # Keep aiohttp's verified system-CA behaviour explicit.  Update metadata,
-    # holiday calendars and update archives all pass through this helper.
-    connector = aiohttp.TCPConnector(ssl=True)
+    # Verify against the trust store the application ships with rather than
+    # whatever OpenSSL was compiled to look for.  Update metadata, holiday
+    # calendars and update archives all pass through this helper.
+    connector = aiohttp.TCPConnector(ssl=default_ssl_context())
     effective_headers = _default_headers()
     if headers:
         effective_headers.update(headers)

--- a/src/utils/tls.py
+++ b/src/utils/tls.py
@@ -1,0 +1,103 @@
+"""The trust store every outbound HTTPS request uses.
+
+A packaged build ships its own OpenSSL, compiled with an ``OPENSSLDIR`` that
+exists on the build runner and not on a user's machine.  Carrying no CA bundle
+of its own, that OpenSSL starts with zero trusted roots, so every request fails
+certificate verification and the downloader -- correctly treating a certificate
+failure as terminal -- reports an SSL error for every date and then opens the
+host circuit breaker.  That is what withdrew the v1.1.0 release; the record is
+in ``docs/engineering/RELEASE_BUILD_EVIDENCE.md``.
+
+The trust store is therefore chosen here, explicitly and in one place, rather
+than inherited from whatever the interpreter happened to be compiled against.
+``certifi`` ships the bundle as an ordinary file inside the package, so the same
+certificates are used whether the application runs from source or from a
+compiled artifact.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import ssl
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def certificate_bundle_path() -> Optional[Path]:
+    """Return the bundled CA certificate file, or ``None`` if it is absent.
+
+    ``None`` means the packaging step failed to include ``certifi``'s data file,
+    or the dependency is missing from an older source install.  The caller falls
+    back to the interpreter's own default store, which is right for a source run
+    and is the failure that must not pass unnoticed in a packaged one.
+    """
+
+    try:
+        import certifi
+    except ImportError:
+        logger.warning("certifi is not installed; falling back to the system trust store")
+        return None
+
+    path = Path(certifi.where())
+    if not path.is_file():
+        logger.warning(f"certifi bundle is missing from the installation: {path}")
+        return None
+    return path
+
+
+@functools.lru_cache(maxsize=1)
+def default_ssl_context() -> ssl.SSLContext:
+    """Return the shared verifying TLS context for outbound requests.
+
+    Cached because loading a bundle of roots per request is measurable, and
+    because aiohttp is happy to share one context across sessions.  Hostname
+    checking and certificate verification stay at their defaults: this exists to
+    give OpenSSL certificates to verify against, never to skip verification.
+    """
+
+    bundle = certificate_bundle_path()
+    if bundle is not None:
+        # A truncated or corrupt bundle is worse than no bundle: it looks like a
+        # configured trust store while trusting nothing, and OpenSSL raises here
+        # rather than returning an empty one.  Neither may take the application
+        # down at its first request.
+        try:
+            context = ssl.create_default_context(cafile=str(bundle))
+        except (ssl.SSLError, OSError) as error:
+            logger.warning(f"certificate bundle could not be loaded: {bundle}: {error}")
+        else:
+            if context.get_ca_certs():
+                return context
+            logger.warning(f"certificate bundle loaded no certificates: {bundle}")
+
+    context = ssl.create_default_context()
+    if not context.get_ca_certs() and not _system_store_looks_usable():
+        logger.error(
+            "no trusted CA certificates are available; HTTPS requests will fail "
+            "certificate verification"
+        )
+    return context
+
+
+def _system_store_looks_usable() -> bool:
+    """Whether OpenSSL's own default store holds anything.
+
+    A directory store is loaded lazily, so an empty ``get_ca_certs()`` does not
+    by itself prove the system store is unusable; this keeps the diagnostic above
+    from crying wolf on the Linux layouts that use a hashed directory.  The
+    directory has to contain something, though -- macOS ships an empty
+    ``/etc/ssl/certs``, and an empty directory trusts nothing.
+    """
+
+    paths = ssl.get_default_verify_paths()
+    if paths.cafile and Path(paths.cafile).is_file():
+        return True
+    if not paths.capath:
+        return False
+    try:
+        return any(Path(paths.capath).iterdir())
+    except OSError:
+        return False

--- a/src/utils/transport_pool.py
+++ b/src/utils/transport_pool.py
@@ -13,6 +13,7 @@ from urllib.parse import urlsplit
 import aiohttp
 
 from ..core.exceptions import CircuitOpenError, NetworkError
+from .tls import default_ssl_context
 
 
 @dataclass
@@ -62,7 +63,7 @@ class TransportPool:
             keepalive_timeout=60,
             enable_cleanup_closed=sys.version_info < (3, 13),
             force_close=False,
-            ssl=True,
+            ssl=default_ssl_context(),
         )
         self.session = aiohttp.ClientSession(
             timeout=timeout,

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -101,7 +101,9 @@ def test_smoke_test_uses_isolated_gui_config(tmp_path, monkeypatch):
             config_path = Path(command[command.index("--config") + 1])
             config = release.yaml.safe_load(config_path.read_text(encoding="utf-8"))
             Path(config["data_paths"]["base_folder"]).mkdir(parents=True)
-        return type("Result", (), {"returncode": 0, "stderr": b""})()
+        return type(
+            "Result", (), {"returncode": 0, "stdout": b"TLS verification passed.\n", "stderr": b""}
+        )()
 
     monkeypatch.setattr(release.subprocess, "run", fake_run)
     release.smoke_test(executable, "linux")

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -107,8 +107,10 @@ def test_smoke_test_uses_isolated_gui_config(tmp_path, monkeypatch):
     release.smoke_test(executable, "linux")
 
     assert calls[0][0][-1] == "--help"
-    gui_command, gui_options = calls[1]
-    assert "--smoke-gui" in gui_command
+    assert calls[1][0][-1] == "--verify-tls"
+    gui_command, gui_options = next(
+        call for call in calls if "--smoke-gui" in call[0]
+    )
     assert gui_options["env"]["QT_QPA_PLATFORM"] == "offscreen"
     assert gui_options["env"]["HOME"] == gui_options["env"]["USERPROFILE"]
 

--- a/tests/test_tls_trust_store.py
+++ b/tests/test_tls_trust_store.py
@@ -9,6 +9,7 @@ whatever OpenSSL was compiled to look for.
 
 import asyncio
 from datetime import date
+from pathlib import Path
 import ssl
 import sys
 from types import SimpleNamespace
@@ -17,6 +18,8 @@ import aiohttp
 import pytest
 
 import build_nuitka_cross_platform as packaging
+import main as application
+import package_release_artifact as packager
 from src.services.corporate_actions import CorporateActionClient
 from src.services.pipeline_telemetry import PipelineTelemetry
 from src.utils import tls
@@ -147,3 +150,58 @@ def test_corporate_action_requests_verify_against_the_shared_context(
         assert connector._ssl is default_ssl_context()
     finally:
         asyncio.run(connector.close())
+
+
+def test_tls_check_passes_when_a_bundle_is_present_and_the_request_succeeds(
+    monkeypatch, capsys
+):
+    requested = {}
+
+    def fake_fetch(url, timeout=None, **_kwargs):
+        requested["url"] = url
+        return "__version__ = \"1.1.0\"\n"
+
+    monkeypatch.setattr("src.utils.http_client.fetch_text_sync", fake_fetch)
+    assert application.run_tls_check() == 0
+    assert requested["url"].startswith("https://")
+    assert "TLS verification passed" in capsys.readouterr().out
+
+
+def test_tls_check_fails_when_the_request_cannot_be_verified(monkeypatch, capsys):
+    def refuse(_url, timeout=None, **_kwargs):
+        raise ssl.SSLCertVerificationError("unable to get local issuer certificate")
+
+    monkeypatch.setattr("src.utils.http_client.fetch_text_sync", refuse)
+    assert application.run_tls_check() == 1
+    assert "TLS verification FAILED" in capsys.readouterr().out
+
+
+def test_tls_check_fails_when_no_bundle_travelled_with_the_build(monkeypatch, capsys):
+    monkeypatch.setattr(tls, "certificate_bundle_path", lambda: None)
+
+    def unreachable(_url, timeout=None, **_kwargs):  # pragma: no cover
+        raise AssertionError("the network must not be reached without a bundle")
+
+    monkeypatch.setattr("src.utils.http_client.fetch_text_sync", unreachable)
+    assert application.run_tls_check() == 1
+    assert "no certificate bundle travelled with this build" in capsys.readouterr().out
+
+
+def test_the_packaged_smoke_test_verifies_tls(monkeypatch, tmp_path):
+    commands = []
+
+    def record(_executable, arguments, _cwd, _environment):
+        commands.append(list(arguments))
+        if "--config" in arguments:
+            # Stand in for the GUI startup the real command performs.
+            config = Path(arguments[arguments.index("--config") + 1])
+            (config.parent / "market-data").mkdir(exist_ok=True)
+
+    monkeypatch.setattr(packager, "executable_path", lambda *_args: tmp_path / "app")
+    monkeypatch.setattr(packager, "_run_smoke_command", record)
+
+    packager.smoke_test(tmp_path / "package", "linux")
+
+    assert ["--verify-tls"] in commands
+    assert ["--help"] in commands
+    assert any("--smoke-gui" in command for command in commands)

--- a/tests/test_tls_trust_store.py
+++ b/tests/test_tls_trust_store.py
@@ -1,0 +1,149 @@
+"""The trust store the application carries, and the sites that must use it.
+
+The withdrawn v1.1.0 artifacts compiled, passed every packaging check and could
+not open a single HTTPS connection, because the bundle had no CA certificates in
+it.  These tests assert the two halves of that: a real bundle travels with the
+application, and every outbound session verifies against it rather than against
+whatever OpenSSL was compiled to look for.
+"""
+
+import asyncio
+from datetime import date
+import ssl
+import sys
+from types import SimpleNamespace
+
+import aiohttp
+import pytest
+
+import build_nuitka_cross_platform as packaging
+from src.services.corporate_actions import CorporateActionClient
+from src.services.pipeline_telemetry import PipelineTelemetry
+from src.utils import tls
+from src.utils.http_client import _single_use_session
+from src.utils.tls import certificate_bundle_path, default_ssl_context
+from src.utils.transport_pool import TransportPool
+
+
+@pytest.fixture(autouse=True)
+def _uncached_context():
+    """Each test builds its own context, so monkeypatching is not defeated."""
+
+    tls.default_ssl_context.cache_clear()
+    yield
+    tls.default_ssl_context.cache_clear()
+
+
+def _pool_config():
+    return SimpleNamespace(
+        download_settings=SimpleNamespace(
+            max_concurrent_downloads=1,
+            rate_limit_delay=0,
+            timeout_seconds=5,
+            connect_timeout_seconds=2,
+            read_timeout_seconds=3,
+            attempt_timeout_seconds=4,
+        ),
+        pipeline_telemetry=PipelineTelemetry(),
+    )
+
+
+def test_application_carries_its_own_certificate_bundle():
+    bundle = certificate_bundle_path()
+    assert bundle is not None, "certifi must remain a runtime dependency"
+    assert bundle.is_file()
+    assert bundle.stat().st_size >= packaging.MINIMUM_CA_BUNDLE_BYTES
+
+
+def test_default_context_verifies_against_loaded_authorities():
+    context = default_ssl_context()
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname is True
+    assert context.get_ca_certs(), "context must carry certificates to verify against"
+
+
+def test_context_is_built_once_and_shared():
+    assert default_ssl_context() is default_ssl_context()
+
+
+def test_a_missing_certifi_still_leaves_verification_on(monkeypatch):
+    # A None entry in sys.modules makes ``import certifi`` raise ImportError,
+    # which is the state of a source install predating the dependency.
+    monkeypatch.setitem(sys.modules, "certifi", None)
+    context = default_ssl_context()
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname is True
+
+
+@pytest.mark.parametrize(
+    "content", ["", "-----BEGIN CERTIFICATE-----\nnot a certificate\n"]
+)
+def test_an_unusable_bundle_is_reported_and_does_not_crash(
+    monkeypatch, tmp_path, caplog, content
+):
+    stub = tmp_path / "cacert.pem"
+    stub.write_text(content, encoding="utf-8")
+    monkeypatch.setattr(tls, "certificate_bundle_path", lambda: stub)
+
+    with caplog.at_level("WARNING", logger=tls.logger.name):
+        context = default_ssl_context()
+
+    assert "certificate bundle" in caplog.text
+    assert str(stub) in caplog.text
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname is True
+
+
+def test_single_use_sessions_verify_against_the_shared_context():
+    async def check():
+        session = await _single_use_session(timeout=1)
+        try:
+            assert session.connector._ssl is default_ssl_context()
+        finally:
+            await session.close()
+
+    asyncio.run(check())
+
+
+def test_the_download_pool_verifies_against_the_shared_context():
+    async def check():
+        pool = TransportPool(_pool_config())
+        await pool.start()
+        try:
+            assert pool.session is not None
+            assert pool.session.connector._ssl is default_ssl_context()
+        finally:
+            await pool.close()
+
+    asyncio.run(check())
+
+
+@pytest.mark.parametrize("exchange", ["NSE", "BSE"])
+def test_corporate_action_requests_verify_against_the_shared_context(
+    monkeypatch, exchange
+):
+    captured = {}
+
+    class _StopBeforeNetwork(RuntimeError):
+        pass
+
+    def fake_session(*_args, **kwargs):
+        captured["connector"] = kwargs.get("connector")
+        raise _StopBeforeNetwork
+
+    monkeypatch.setattr(aiohttp, "ClientSession", fake_session)
+    client = CorporateActionClient(timeout=1)
+    day = date(2026, 8, 14)
+
+    with pytest.raises(_StopBeforeNetwork):
+        if exchange == "NSE":
+            asyncio.run(client._fetch_nse("EQ", day, day))
+        else:
+            asyncio.run(client._fetch_bse(day, day))
+
+    connector = captured["connector"]
+    assert connector is not None, "the exchange endpoints must not use the default"
+    try:
+        assert connector._ssl is default_ssl_context()
+    finally:
+        asyncio.run(connector.close())

--- a/tests/test_tls_trust_store.py
+++ b/tests/test_tls_trust_store.py
@@ -187,7 +187,7 @@ def test_tls_check_fails_when_no_bundle_travelled_with_the_build(monkeypatch, ca
     assert "no certificate bundle travelled with this build" in capsys.readouterr().out
 
 
-def test_the_packaged_smoke_test_verifies_tls(monkeypatch, tmp_path):
+def test_the_packaged_smoke_test_verifies_tls(monkeypatch, tmp_path, capsys):
     commands = []
 
     def record(_executable, arguments, _cwd, _environment):
@@ -196,6 +196,9 @@ def test_the_packaged_smoke_test_verifies_tls(monkeypatch, tmp_path):
             # Stand in for the GUI startup the real command performs.
             config = Path(arguments[arguments.index("--config") + 1])
             (config.parent / "market-data").mkdir(exist_ok=True)
+        if "--verify-tls" in arguments:
+            return "Trusted certificate authorities loaded: 137\nTLS verification passed.\n"
+        return ""
 
     monkeypatch.setattr(packager, "executable_path", lambda *_args: tmp_path / "app")
     monkeypatch.setattr(packager, "_run_smoke_command", record)
@@ -205,3 +208,5 @@ def test_the_packaged_smoke_test_verifies_tls(monkeypatch, tmp_path):
     assert ["--verify-tls"] in commands
     assert ["--help"] in commands
     assert any("--smoke-gui" in command for command in commands)
+    # The evidence has to reach the build log, not just the exit code.
+    assert "TLS verification passed." in capsys.readouterr().out

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -10,6 +10,7 @@ from src.utils.async_downloader import (
     DownloadTask,
 )
 from src.utils.http_client import _single_use_session
+from src.utils.tls import default_ssl_context
 
 
 def test_config_download_settings_are_mutable_for_the_runtime(tmp_path):
@@ -49,7 +50,7 @@ def test_http_sessions_use_certificate_verification():
         session = await _single_use_session(timeout=1)
         try:
             assert session.connector is not None
-            assert session.connector._ssl is True
+            assert session.connector._ssl is default_ssl_context()
         finally:
             await session.close()
 


### PR DESCRIPTION
Closes the defect that withdrew v1.1.0. Root cause and reproduction are recorded in `RELEASE_BUILD_EVIDENCE.md`; the work item is `PENDING_TASKS.md` §3.

## The defect

A compiled build ships its own OpenSSL, compiled with `OPENSSLDIR = /Library/Frameworks/Python.framework/Versions/3.13/etc/openssl` — a path that exists on the build runner and nowhere else — and carried no CA bundle of its own. It started with zero trusted roots, so every HTTPS request failed certificate verification, the downloader correctly treated that as terminal, and the host circuit breaker opened. Source runs were never affected: they use the certificates the user's own Python trusts.

## The fix

- **`src/utils/tls.py`** — one place that chooses the trust store, used by all three sites that open connections: the shared helper session, the download transport pool, and the two corporate-action endpoints, which had been taking aiohttp's default connector.
- **`certifi` becomes a runtime dependency**, so the same certificates travel with the application from source or compiled, and the Nuitka command includes its data file (`--include-package-data=certifi`) that Nuitka would otherwise leave behind.
- Verification stays on throughout — this gives OpenSSL certificates to verify against, it never skips verification. A corrupt bundle raises inside `create_default_context` rather than returning an empty one; that is caught, logged, and the system store used instead. Both paths keep `CERT_REQUIRED`.
- The packaging dry run now fails if `certifi` is absent or its bundle is implausibly small — twenty minutes earlier than the alternative.

## Closing the gap that let it ship

Nothing in the packaging pipeline touched the network, so a build with no certificates passed `--help`, `--smoke-gui`, checksum, layout, provenance and Gatekeeper checks and shipped. A source-level test cannot close that gap either: it runs on an interpreter that already trusts the host's certificates — the exact environment the defect hides in.

`--verify-tls` makes the application prove it: a bundle travelled with the build, it loaded authorities, and one real request through the application's own HTTP client completed. It runs **on the compiled artifact during packaging**, between `--help` and `--smoke-gui`. Relying on the host's trust store is treated as failure, not success — otherwise a build that works only on the machine that built it would pass. Its output is printed into the build log, because a passing check that leaves no evidence is how a green tick came to mean nothing last time.

## Verification

Python 3.13: 412 passed (was 398), coverage 77.25%, `ruff` clean, `mypy` clean on 55 files, packaging dry run exit 0, `--smoke-gui` exit 0.
Python 3.10: 412 passed, `--smoke-gui` exit 0.

**Compiled artifacts, three platforms** — [`workflow_dispatch` run 31821982454](https://github.com/pparesh25/NSE_BSE_Downloader/actions/runs/31821982454), all green. Each packaged binary resolved its bundle from **inside the artifact**, not from the host:

| Platform | Bundle the packaged binary loaded | Authorities | Result |
|---|---|---:|---|
| macOS 15 ARM64 | `…/main.app/Contents/MacOS/certifi/cacert.pem` | 121 | passed |
| Ubuntu 24.04 x64 | `/tmp/onefile_…/certifi/cacert.pem` | 121 | passed |
| Windows 2022 x64 | `…\Temp\onefile_…\certifi\cacert.pem` | 121 | passed |

That is the property no source-level test could establish: `--include-package-data=certifi` puts the bundle in the artifact, and `certifi.where()` resolves to it under both Nuitka app and onefile modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)