### PR TITLE
fix: stop the TLS check failing a build over the server's answer

### DIFF
--- a/main.py
+++ b/main.py
@@ -310,7 +310,11 @@ def run_tls_check() -> int:
     during packaging rather than only against the source tree under pytest.
     """
 
-    from src.utils.http_client import fetch_text_sync
+    import ssl
+
+    import aiohttp
+
+    from src.utils.http_client import HTTPStatusError, fetch_text_sync
     from src.utils.tls import certificate_bundle_path, default_ssl_context
 
     bundle = certificate_bundle_path()
@@ -332,8 +336,22 @@ def run_tls_check() -> int:
         # The updater's own endpoint, reached through the application's own HTTP
         # client, so this exercises the shipped path rather than a private one.
         fetch_text_sync(url, timeout=30)
-    except Exception as error:
+    # Order matters, as it does in the downloader's own classifier: aiohttp's
+    # certificate errors subclass its connection errors.
+    except (ssl.SSLError, aiohttp.ClientSSLError) as error:
         print(f"TLS verification FAILED for {url}: {error!r}")
+        return 1
+    except HTTPStatusError as answered:
+        # A status line can only arrive after the handshake completed and the
+        # certificate verified.  What the server chose to answer -- a rate limit,
+        # a 404, an outage -- is not this check's business, and failing a release
+        # build over it would be a false alarm about certificates.
+        print(f"TLS verified: the endpoint answered HTTP {answered.status}.")
+        return 0
+    except Exception as error:
+        # Not a certificate problem, but nothing was proved either.  Say which
+        # it is, so a reader retries instead of debugging the trust store.
+        print(f"TLS verification INCONCLUSIVE: {url} was unreachable: {error!r}")
         return 1
 
     print("TLS verification passed.")

--- a/tests/test_tls_trust_store.py
+++ b/tests/test_tls_trust_store.py
@@ -23,7 +23,7 @@ import package_release_artifact as packager
 from src.services.corporate_actions import CorporateActionClient
 from src.services.pipeline_telemetry import PipelineTelemetry
 from src.utils import tls
-from src.utils.http_client import _single_use_session
+from src.utils.http_client import HTTPStatusError, _single_use_session
 from src.utils.tls import certificate_bundle_path, default_ssl_context
 from src.utils.transport_pool import TransportPool
 
@@ -172,6 +172,55 @@ def test_tls_check_fails_when_the_request_cannot_be_verified(monkeypatch, capsys
         raise ssl.SSLCertVerificationError("unable to get local issuer certificate")
 
     monkeypatch.setattr("src.utils.http_client.fetch_text_sync", refuse)
+    assert application.run_tls_check() == 1
+    assert "TLS verification FAILED" in capsys.readouterr().out
+
+
+def test_an_http_status_still_proves_the_certificate_verified(monkeypatch, capsys):
+    # A rate limit, a 404 or an outage arrives only after a completed handshake.
+    # Treating it as a certificate failure would fail release builds at random.
+    def rate_limited(url, timeout=None, **_kwargs):
+        raise HTTPStatusError(429, "Too Many Requests", url)
+
+    monkeypatch.setattr("src.utils.http_client.fetch_text_sync", rate_limited)
+    assert application.run_tls_check() == 0
+    output = capsys.readouterr().out
+    assert "TLS verified" in output
+    assert "429" in output
+
+
+def test_an_unreachable_endpoint_is_reported_as_inconclusive(monkeypatch, capsys):
+    def unreachable(_url, timeout=None, **_kwargs):
+        raise OSError("nodename nor servname provided")
+
+    monkeypatch.setattr("src.utils.http_client.fetch_text_sync", unreachable)
+    assert application.run_tls_check() == 1
+    output = capsys.readouterr().out
+    assert "INCONCLUSIVE" in output
+    assert "FAILED" not in output
+
+
+def test_a_certificate_error_is_not_mistaken_for_a_connection_error(
+    monkeypatch, capsys
+):
+    # aiohttp reports a missing trust store as ClientConnectorCertificateError,
+    # which subclasses ClientConnectorError.  Classified by connection first, the
+    # very defect this check exists for would be called "inconclusive".
+    def no_trust_store(_url, timeout=None, **_kwargs):
+        raise aiohttp.ClientConnectorCertificateError(
+            aiohttp.client_reqrep.ConnectionKey(
+                host="raw.githubusercontent.com",
+                port=443,
+                is_ssl=True,
+                ssl=None,
+                proxy=None,
+                proxy_auth=None,
+                proxy_headers_hash=None,
+            ),
+            ssl.SSLCertVerificationError("unable to get local issuer certificate"),
+        )
+
+    monkeypatch.setattr("src.utils.http_client.fetch_text_sync", no_trust_store)
     assert application.run_tls_check() == 1
     assert "TLS verification FAILED" in capsys.readouterr().out
 


### PR DESCRIPTION
Found by running the packaged `darwin-arm64` artifact from [run 31821982454](https://github.com/pparesh25/NSE_BSE_Downloader/actions/runs/31821982454) on a real Mac — the machine where the withdrawn build failed.

## What the run showed

```
Certificate bundle: …/NSE BSE Data Downloader.app/Contents/MacOS/certifi/cacert.pem
Trusted certificate authorities loaded: 121
TLS verification FAILED …: HTTPStatusError(status=429, message='429: Too Many Requests', …)
```

The trust store worked. The bundle resolved from inside the app, 121 authorities loaded, and GitHub answered **HTTP 429** after several probes in a row. A status line can only arrive after the handshake completed and the certificate verified — so the check printed failure on evidence of success.

Same machine, same endpoint, same minute, the withdrawn build (`059f497`) still says:

```
CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate
```

It never reaches the HTTP layer at all. That contrast is the proof the fix works; the 429 is only the check misreading it.

## Why it matters

Left alone, this fails release builds at random — a rate limit, a 404, an endpoint outage — and every one of those sends someone to debug certificates.

## The change

| Outcome | Verdict |
|---|---|
| Certificate error | **FAILED** — the defect this check exists for |
| Any HTTP status | **passed**, naming the status |
| DNS / refused / timeout | **INCONCLUSIVE**, still non-zero: nothing was proved |

Certificate errors are matched before connection errors, as `async_downloader._classify_by_exception` already does: aiohttp reports a missing trust store as `ClientConnectorCertificateError`, which subclasses `ClientConnectorError`, so the wrong order would file the very defect this check exists for under "inconclusive". A test pins that ordering.

## Verification

Python 3.13: 415 passed (was 412), coverage 77.30%, `ruff` clean, `mypy` clean on 55 files, `--smoke-gui` exit 0.
Python 3.10: 415 passed, `--smoke-gui` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)