### PR TITLE
release: republish the 1.1 line as v1.1.1 with a working trust store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
-# NSE/BSE Data Downloader v1.1.0 (PySide6)
+# NSE/BSE Data Downloader v1.1.1 (PySide6)
 
 > ### Upgrading from v1.0.1? Read **[UPGRADE.md](UPGRADE.md)** first.
 > v1.1.0 replaced PyQt6 with PySide6 and requires Python 3.10 or newer. Copying these
 > files over an existing v1.0.1 install **without** running
 > `pip install -r requirements.txt` will stop the app from starting.
 >
-> **The prebuilt v1.1.0 applications have been withdrawn**, so no release is published
-> at the moment. They carried no certificate store and could not download anything;
-> running from source is not affected. Install from source with the steps below until a
-> corrected build is published.
+> Prebuilt applications that need no setup are on the
+> [releases page](https://github.com/pparesh25/NSE_BSE_Downloader/releases/latest).
+>
+> **Using a v1.1.0 prebuilt application?** Replace it. Those builds shipped without a
+> certificate store and could not download anything; they were withdrawn and v1.1.1
+> fixes it. Source installs were never affected.
 
 A desktop downloader that turns legacy and current NSE/BSE reports into one stable daily-file format.
 
 ![Python](https://img.shields.io/badge/python-3.10+-blue.svg)
 ![PySide6](https://img.shields.io/badge/GUI-PySide6-green.svg)
 ![License](https://img.shields.io/badge/license-GPL3.0-blue.svg)
-![Version](https://img.shields.io/badge/version-1.1.0-brightgreen.svg)
+![Version](https://img.shields.io/badge/version-1.1.1-brightgreen.svg)
 
 ## Features
 
@@ -61,8 +63,8 @@ Version 1.1 keeps the existing `~/NSE_BSE_Data/` data root and
 `~/.nse_bse_downloader/` preference directory. Existing seven-column daily files
 remain readable and are not rewritten merely by launching the application. A date
 downloaded again is published under the current stable nine-column EQ/SME/FO
-contract. Back up important user data before a major upgrade. While no release is
-published, install from the immutable `v1.1.0` tag rather than an archive from a
+contract. Back up important user data before a major upgrade and use the official
+GitHub Release assets, or the immutable `v1.1.1` tag, rather than an archive from a
 mutable branch.
 
 ## Nuitka packaging and release trust
@@ -287,6 +289,17 @@ platform-specific Nuitka command generation and the default no-build guard. The
 strict project mypy configuration currently passes all 45 source files.
 
 ## Version history
+
+### v1.1.1 (2026-08-18)
+
+- Gave the packaged application its own certificate authorities. v1.1.0 builds
+  shipped without a trust store, so every download failed certificate
+  verification and the host circuit breaker opened. Source runs were unaffected.
+- Routed the corporate-action endpoints through the same trust store as every
+  other request.
+- Made packaging prove it: a compiled build must complete one verified HTTPS
+  request before it can become a release, and a build with no certificate
+  bundle now fails the packaging dry run.
 
 ### v1.1.0 (2026-07-31)
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,28 +1,44 @@
-# Upgrading from v1.0.1 to v1.1.0 — read this first
+# Upgrading from v1.0.1 to v1.1.1 — read this first
 
 **If you arrived here from the "New version available" popup inside the app, this file
 is the one you need.** The download you just received is application source code, not a
-ready-to-run installer, and v1.1.0 needs a different set of libraries than v1.0.1 did.
+ready-to-run installer, and v1.1 needs a different set of libraries than v1.0.1 did.
 
-There were two ways forward. **Option A is unavailable right now**, so Option B is the
-one to follow.
+Two ways forward. Pick one.
+
+> **If you already installed a v1.1.0 prebuilt application, replace it with v1.1.1.**
+> Those builds shipped without a certificate store, so every download failed with an
+> "SSL certificate issue" no matter which dates you chose. They were withdrawn. Nothing
+> you downloaded with them is wrong -- they could not write anything at all -- and your
+> data folder is untouched. Source installs were never affected.
 
 ---
 
-## Option A — Download a prebuilt application (withdrawn)
+## Option A — Download a prebuilt application (easiest)
 
-**The prebuilt v1.1.0 applications have been withdrawn, and no release is published at
-the moment.** The releases page is empty on purpose; there is nothing there to
-download.
+Go to the releases page and download the file for your system:
 
-They were withdrawn because they could not download market data at all. The packaged
-application carried its own copy of OpenSSL but no certificate store, so every HTTPS
-request to NSE and BSE failed certificate verification, and the app reported an "SSL
-certificate issue" for every date. The exchanges were fine; the build was not.
+**https://github.com/pparesh25/NSE_BSE_Downloader/releases/latest**
 
-**Running from source is not affected by this**, because it uses the certificates your
-own Python installation already trusts. Use Option B. This section will return, with
-the file names and first-launch instructions, once a corrected build is published.
+| Your system | File to download |
+|---|---|
+| Windows 10/11, 64-bit | `NSE_BSE_Downloader-1.1.1-windows-x64.zip` |
+| Mac with Apple Silicon (M1/M2/M3/M4) | `NSE_BSE_Downloader-1.1.1-darwin-arm64.zip` |
+| Linux, 64-bit | `NSE_BSE_Downloader-1.1.1-linux-x64.zip` |
+
+Each file has a matching `.sha256` file next to it if you want to verify the download.
+
+Unzip it and run it. Nothing else to install — Python and all libraries are bundled.
+
+> **Intel Mac users:** there is no prebuilt build for Intel Macs. Use Option B.
+
+> **macOS first launch:** the app is not signed with an Apple Developer certificate, so
+> macOS will refuse to open it on the first try. This is expected. **Right-click** (or
+> Control-click) the app icon, choose **Open**, then click **Open** in the dialog. You
+> only need to do this once.
+
+> **Windows first launch:** SmartScreen may show "Windows protected your PC" for the same
+> reason. Click **More info** → **Run anyway**.
 
 ---
 

--- a/docs/engineering/PENDING_TASKS.md
+++ b/docs/engineering/PENDING_TASKS.md
@@ -1,6 +1,6 @@
 # Pending engineering tasks
 
-Last reviewed: 2026-08-14 (Asia/Kolkata)
+Last reviewed: 2026-08-18 (Asia/Kolkata)
 Repository branch at review: `main`
 
 ## Working convention
@@ -14,10 +14,10 @@ This file is the central index for approved but incomplete engineering work. Det
 research and evidence files remain authoritative references, but every deferred topic
 must also be recorded here so it is not lost between phases.
 
-## 0. v1.1.0 release publication — published 2026-08-09, withdrawn 2026-08-14
+## 0. v1.1 release publication — 1.1.0 published, withdrawn, republished as 1.1.1
 
-Status: **Withdrawn.** Paused on 2026-08-06 so that code-level defect remediation could
-go first; resumed once Phase 3 of
+Status: **Superseded by v1.1.1.** Paused on 2026-08-06 so that code-level defect
+remediation could go first; resumed once Phase 3 of
 [CODE_DEFECT_REMEDIATION_PLAN.md](CODE_DEFECT_REMEDIATION_PLAN.md) closed, which
 removed every defect the pause existed to avoid shipping.
 
@@ -29,7 +29,11 @@ The `v1.1.0` tag remains, so
 <https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/v1.1.0> still resolves to
 the tag and its source archives. `main` still reads `1.1.0`, so installed v1.0.1
 clients still announce the update; `README.md` and `UPGRADE.md` were corrected to send
-them to the source install rather than to an empty releases page.
+them to the source install rather than to an empty releases page, and restored when
+v1.1.1 was published. Release notes: [RELEASE_NOTES_1.1.1.md](RELEASE_NOTES_1.1.1.md).
+
+The withdrawal cost one release cycle and no user data: the broken builds could not
+write anything, because they could not download anything.
 
 The steps below are kept as the record of how it was done, and as the template for the
 next release.
@@ -238,10 +242,10 @@ bounded file-write improvements. The current pipeline already batches history me
 in memory, but it must still publish thousands of individual files for a fresh
 Select-All run.
 
-## 3. Packaged builds have no certificate store
+## 3. Packaged builds have no certificate store — done 2026-08-18
 
-Status: Root cause established and reproduced; fix not started. **Blocks any
-republication of v1.1.0 or any later release.**
+Status: **Done.** Fixed, merged and proved on compiled artifacts for all three
+platforms before v1.1.1 was published.
 
 Detailed record: [RELEASE_BUILD_EVIDENCE.md](RELEASE_BUILD_EVIDENCE.md), "Why the
 release was withdrawn".
@@ -265,15 +269,25 @@ verification. `certifi` is not a dependency at all, and `http_client.py` passes
   variable set at startup: the environment variable works, but it is invisible to the
   test suite and to anyone reading the code.
 
-### Required evidence
+### Evidence produced
 
-- A test that fails without the fix: assert the connector's TLS context loads CA
-  certificates, so a future packaging change cannot silently drop them again.
-- **A compiled artifact on each platform observed completing a real HTTPS request.**
-  This is the gap that let the defect ship. Every existing check — checksums, layout,
-  provenance, Gatekeeper, `--smoke-gui` — passes on a build that cannot open a TLS
-  connection, because none of them touch the network.
-- Verify macOS, Windows and Linux separately. The macOS build is the one reproduced
-  against; Windows almost certainly shares the defect, and Linux may survive by finding
-  `/etc/ssl/certs`. Do not infer one platform from another.
-- Re-run the full gate set in both supported environments.
+- `tests/test_tls_trust_store.py` asserts that a bundle travels with the application
+  and that all three connection sites use it, so a future packaging change cannot
+  silently drop them again.
+- **A compiled artifact on each platform completed a real HTTPS request**, in
+  `workflow_dispatch` run 31821982454. Each resolved its bundle from *inside* the
+  artifact, not from the host: `…/main.app/Contents/MacOS/certifi/cacert.pem`,
+  `/tmp/onefile_…/certifi/cacert.pem`, `…\Temp\onefile_…\certifi\cacert.pem`,
+  121 authorities each. That is the property no source-level test can establish.
+- A/B on the owner's Mac, same endpoint, same minute: the withdrawn build still fails
+  with `CERTIFICATE_VERIFY_FAILED`; the fixed build reaches the HTTP layer.
+- Full gate set re-run in both supported environments.
+
+### What it changed about how a release is verified
+
+`--verify-tls` now runs on the compiled artifact during packaging, and prints which
+bundle travelled and how many authorities loaded. Running the packaged artifact on a
+real machine also found a defect in that check itself: it read an HTTP 429 as a
+certificate failure, which would have failed release builds at random. A status line
+proves the handshake completed, so it now passes, and an unreachable endpoint is
+reported as inconclusive rather than as a certificate problem (PR #15).

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -22,6 +22,7 @@ formatting alone; three of the older audits are largely in Gujarati for that rea
 | [PROJECT_REVIEW_2026-08-06.md](PROJECT_REVIEW_2026-08-06.md) | The review those defects came from, with evidence |
 | [RELEASE_IMPLEMENTATION_PLAN.md](RELEASE_IMPLEMENTATION_PLAN.md) | Staged plan for the v1.1.0 cutover and after |
 | [RELEASE_RUNBOOK.md](RELEASE_RUNBOOK.md) | Verified steps for branch protection, release build, signing |
+| [RELEASE_NOTES_1.1.1.md](RELEASE_NOTES_1.1.1.md) | User-facing notes for v1.1.1, the republished release |
 | [RELEASE_NOTES_1.1.0.md](RELEASE_NOTES_1.1.0.md) | User-facing notes for v1.1.0, published then withdrawn |
 | [CANONICAL_REPOSITORY_MIGRATION.md](CANONICAL_REPOSITORY_MIGRATION.md) | Record of the PySide6 port becoming canonical here |
 

--- a/docs/engineering/RELEASE_BUILD_EVIDENCE.md
+++ b/docs/engineering/RELEASE_BUILD_EVIDENCE.md
@@ -1,107 +1,70 @@
 # Release build evidence
 
-Date: 2026-08-09 (Asia/Kolkata)
-Tag: `v1.1.0`
-Source commit built and published: `059f497c7716f9910ea70a2b8ea0e1d2dcb769d4`
-Release status: **withdrawn 2026-08-14.** Published on 2026-08-09, then unpublished
-with all six assets after the shipped builds proved unable to download any market
-data. The `v1.1.0` tag remains; the Release does not, so
-<https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/v1.1.0> now shows the
-tag and its source archives only. See "Why the release was withdrawn" below.
+Date: 2026-08-18 (Asia/Kolkata)
+Tag: `v1.1.1`
+Source commit built: `354b6180faab85535c5fd0843b52f5d12ce591a5`
+Release status: **built and verified; publication pending**
 
 ## Purpose
 
 This record describes the artifacts that were actually shipped. An integrity record
 pinned to a superseded commit is worse than none, because it invites trust in a stale
 hash, so this file is rewritten at each release against the tagged commit rather than
-appended to. The superseded rehearsal evidence it replaces is summarized at the end.
+appended to. What it replaces is summarized at the end.
 
 ## What was built
 
-GitHub Actions run [`31274716003`](https://github.com/pparesh25/NSE_BSE_Downloader/actions/runs/31274716003),
-triggered by the `v1.1.0` tag push. Three isolated Python 3.13 Nuitka builds, each
+GitHub Actions run [`32177266322`](https://github.com/pparesh25/NSE_BSE_Downloader/actions/runs/32177266322),
+triggered by the `v1.1.1` tag push. Three isolated Python 3.13 Nuitka builds, each
 installing only `requirements.txt` and `requirements-build.txt` and asserting that
 pytest and mypy are absent:
 
 | Target | Runner | Wall clock |
 | --- | --- | ---: |
-| macOS 15 ARM64 | `macos-15` | 18 min 30 s |
-| Ubuntu 24.04 x64 | `ubuntu-24.04` | 20 min 23 s |
-| Windows Server 2022 x64 | `windows-2022` | 27 min 18 s |
+| macOS 15 ARM64 | `macos-15` | 18 min 41 s |
+| Ubuntu 24.04 x64 | `ubuntu-24.04` | 15 min 36 s |
+| Windows Server 2022 x64 | `windows-2022` | 27 min 42 s |
 
 The Quality Gates run for the same commit also passed: tests on Python 3.10 and 3.13,
 Ruff, mypy, and the packaging dry run.
 
-## Published assets
+## Built assets
 
 | Asset | Bytes | SHA-256 |
 | --- | ---: | --- |
-| `NSE_BSE_Downloader-1.1.0-darwin-arm64.zip` | 65,188,287 | `178ed931997321151248a7e7fe38d61e7e7491e4ade12a00ddd6d7c74c93eb65` |
-| `NSE_BSE_Downloader-1.1.0-windows-x64.zip` | 48,394,086 | `660b0f1c521616778dd79c19925aa06fb0f1d4c7ff36301d614d9ef9dcebd0ab` |
-| `NSE_BSE_Downloader-1.1.0-linux-x64.zip` | 84,434,022 | `bacafebe4695861fc7c8aa519d4327212285c8a0b8f154371f1e10f061bbccc3` |
+| `NSE_BSE_Downloader-1.1.1-darwin-arm64.zip` | 65,356,710 | `b3f1fe0da90207c0e0ed9830c2b209af94351c1c28d47fccd4721dc1768e2f88` |
+| `NSE_BSE_Downloader-1.1.1-windows-x64.zip` | 48,543,930 | `c33428b7a8cf4a47ccf4320eb75548ed2de90c6ffd0a716884f93a57b0182d4d` |
+| `NSE_BSE_Downloader-1.1.1-linux-x64.zip` | 84,643,953 | `53d10708c0ad3d71c53ffc16696c894db728296a4145af322360b0716a497004` |
 
-Each ZIP shipped with its `.sha256` sidecar in `shasum -c` format, so a user could
-verify a download without trusting this document. The assets are no longer
-downloadable; the digests are kept so a copy already downloaded can still be
-identified as one of these builds.
-
-## Why the release was withdrawn
-
-The three published applications could not download market data at all. Every date in
-a run failed, the log reported an SSL certificate issue for each one, and the host
-circuit breaker then opened and skipped the rest.
-
-Reproduced on 2026-08-14 against the withdrawn `darwin-arm64` asset, whose
-`BUILD-METADATA.json` records `git_commit 059f497` — the tagged commit in this record:
-
-- The bundle ships its own `libssl.3.dylib` and `libcrypto.3.dylib`, compiled with
-  `OPENSSLDIR = /Library/Frameworks/Python.framework/Versions/3.13/etc/openssl`. That
-  is the python.org framework path present on the build runner; it does not exist on
-  an end user's machine.
-- No `cacert.pem` is bundled anywhere in the app, and `certifi` is not a dependency,
-  so the bundled OpenSSL starts with **zero trusted roots**.
-- Run as shipped, the packaged application fails its own update check with
-  `CERTIFICATE_VERIFY_FAILED ... unable to get local issuer certificate`.
-- The same binary, with `SSL_CERT_FILE=/etc/ssl/cert.pem`, completes that check
-  silently. Nothing else changed between the two runs.
-
-Classifying a certificate failure as terminal is correct, so the downloader behaved as
-designed; the trust store was simply absent. Running from source is unaffected,
-because it uses the certificates the user's own Python installation already trusts.
-
-**Why the verification below did not catch it.** Every check in this record is
-satisfied by a build that cannot open a TLS connection. `--smoke-gui` constructs the
-GUI and exits; it makes no network request. Checksums, layout, provenance and
-Gatekeeper all describe the file, not its ability to work. The one property a user
-cares about — that it can fetch a bhavcopy — was never asserted against a compiled
-artifact on any platform.
-
-The macOS asset is the one reproduced against. The Windows build almost certainly
-carries the same defect; the Linux build may find `/etc/ssl/certs` and survive. Each
-platform must be verified separately rather than inferred from this one.
+Each ZIP ships with its `.sha256` sidecar in `shasum -c` format, so a user can verify
+a download without trusting this document.
 
 ## Independent verification
 
 Performed against the downloaded files, not inferred from a green tick.
 
 - **Checksums.** All three sidecars verified with `shasum -a 256 -c`: `OK`.
-- **Layout.** Each archive has exactly one top-level directory, named after the
-  archive itself.
-- **Provenance.** Every `BUILD-METADATA.json` records `version 1.1.0`,
-  `git_commit 059f497c7716…` — the tagged commit — and `trust_status: unsigned`.
-- **The packaged application starts.** The macOS bundle was extracted and run with
-  `--smoke-gui` under a temporary `HOME`, so it could not reach the real data root:
-  **exit code 0**. It created its folders under the temporary home only.
-- **The single-instance lock works in the packaged build.** `.state/app.lock` was
-  created during the run and cleared on exit, which exercises the Phase 3.5 guard in a
-  compiled binary rather than only under pytest.
-- **Gatekeeper.** `codesign -dv` reports `Signature=adhoc`, `TeamIdentifier=not set`,
-  and `spctl --assess --type execute` reports `rejected`. This is the documented,
-  expected behaviour for an unsigned build and is exactly what `UPGRADE.md` and the
-  release notes prepare users for.
-- **From the outside.** Every asset was downloaded again from the published Release
-  page — not from the build directory — and re-verified against the sidecars that came
-  down with them.
+- **Provenance.** Every `BUILD-METADATA.json` records `version 1.1.1`,
+  `git_commit 354b6180faab…` — the tagged commit — and `trust_status: unsigned`.
+- **Each build can open a TLS connection.** This is the check the previous release did
+  not have. Every packaged binary completed one real verified HTTPS request during
+  packaging, and each resolved its certificate bundle from *inside* the artifact rather
+  than from the machine that built it:
+
+  | Platform | Bundle the packaged binary loaded | Authorities |
+  | --- | --- | ---: |
+  | macOS | `…/main.app/Contents/MacOS/certifi/cacert.pem` | 121 |
+  | Linux | `/tmp/onefile_…/certifi/cacert.pem` | 121 |
+  | Windows | `…\Temp\onefile_…\certifi\cacert.pem` | 121 |
+
+- **On a machine that is not the build machine.** The macOS asset was downloaded,
+  extracted and run on the owner's Mac — the same Mac where the withdrawn v1.1.0 build
+  failed. `--verify-tls` passed with 121 authorities loaded from inside the app bundle.
+  The same Mac still reproduces `CERTIFICATE_VERIFY_FAILED` with the withdrawn build,
+  which is what makes this a controlled comparison rather than an assertion.
+- **The packaged application starts.** The macOS bundle was run with `--smoke-gui`
+  under a temporary `HOME` and an isolated data root, so it could not reach the real
+  one: **exit code 0**, and it created its folders under the temporary root only.
 
 ## Trust status
 
@@ -115,23 +78,50 @@ documented for users rather than hidden.
 updater **notification-only** for every platform. It never executes a downloaded
 artifact without a checksum bound in advance.
 
-## What remains, before anything is published again
+## What remains, after this release
 
-1. **A certificate store in the packaged build**, and a check that proves it. Nothing
-   may be republished until a compiled artifact on each platform is observed to
-   complete a real HTTPS request. Tracked in
-   [PENDING_TASKS.md](PENDING_TASKS.md) §3.
-2. Application icons for macOS, Windows and Linux.
-3. Signing credentials: Developer ID plus notarization for macOS, and a Windows
+1. Application icons for macOS, Windows and Linux.
+2. Signing credentials: Developer ID plus notarization for macOS, and a Windows
    certificate if that route is chosen.
-4. A macOS Intel build, or a documented source-only route for Intel hardware.
-5. Automating the Release step itself: both workflows still end at
-   `actions/upload-artifact`, so publishing was manual this time.
+3. A macOS Intel build, or a documented source-only route for Intel hardware.
+4. Automating the Release step itself: both workflows still end at
+   `actions/upload-artifact`, so publishing is still manual.
 
 ## Superseded evidence
 
-Two earlier records are retained here in summary only, because their hashes describe
-artifacts that were never published:
+### v1.1.0 — published 2026-08-09, withdrawn 2026-08-14
+
+Built from tag `v1.1.0` at commit `059f497`, run `31274716003`, all three platforms
+green, checksums verified, packaged macOS app launched. It was withdrawn with all six
+assets because the builds could not download anything.
+
+The bundle shipped its own `libssl.3` and `libcrypto.3`, compiled with
+`OPENSSLDIR = /Library/Frameworks/Python.framework/Versions/3.13/etc/openssl` — the
+runner's python.org framework path, absent on a user's machine — and no `cacert.pem`
+was included, because `certifi` was not a dependency. The packaged application
+therefore started with zero trusted roots. Every HTTPS request failed certificate
+verification, the downloader correctly treated that as terminal, and the host circuit
+breaker then skipped the remaining dates. Running from source was never affected.
+
+Its digests are not repeated here: those files are not downloadable and an integrity
+record for a withdrawn artifact invites exactly the mistaken trust this file exists to
+prevent. The commit history holds them if they are ever needed.
+
+**Why the verification of that release did not catch it.** Every check in this file's
+previous revision — checksums, layout, provenance, Gatekeeper, `--smoke-gui` — is
+satisfied by a build that cannot open a TLS connection, because none of them touched
+the network. The one property a user cares about, that the application can fetch a
+bhavcopy, was never asserted against a compiled artifact on any platform. That is the
+gap `--verify-tls` closes, and it is why this file now leads with it.
+
+Running the artifact on a real machine also proved worth doing for its own sake: it
+found that the new check misread an HTTP 429 rate limit as a certificate failure, which
+would have failed later release builds at random. Fixed in PR #15 before this release.
+
+### Earlier rehearsals
+
+Two records are retained in summary only, because their hashes describe artifacts that
+were never published:
 
 - **Local macOS ARM64 build, commit `4d25c17e`, 2026-08-05.** Built from the primary
   development environment, so it pulled in mypy, pydantic, PyObjC, openpyxl, lxml and

--- a/docs/engineering/RELEASE_NOTES_1.1.1.md
+++ b/docs/engineering/RELEASE_NOTES_1.1.1.md
@@ -1,0 +1,81 @@
+# v1.1.1
+
+> ### If you installed a v1.1.0 prebuilt application, replace it with this one.
+> Those builds could not download anything. They shipped without a certificate store,
+> so every date failed with an "SSL certificate issue" and the app then stopped trying
+> that exchange for a while. The exchanges were fine; the build was not. They have been
+> withdrawn. Your data folder is untouched — those builds could not write to it at all.
+>
+> **If you run from source, you were never affected.** Source installs use the
+> certificates your own Python already trusts. Upgrading is still worth it: run
+> `pip install -r requirements.txt` again, because `certifi` is now a dependency.
+
+## Downloads
+
+| Your system | File |
+|---|---|
+| Windows 10/11, 64-bit | `NSE_BSE_Downloader-1.1.1-windows-x64.zip` |
+| Mac, Apple Silicon (M1–M4) | `NSE_BSE_Downloader-1.1.1-darwin-arm64.zip` |
+| Linux, 64-bit | `NSE_BSE_Downloader-1.1.1-linux-x64.zip` |
+
+Nothing else to install — Python and all libraries are bundled. Each file has a
+matching `.sha256` if you want to verify your download:
+
+```bash
+shasum -a 256 -c NSE_BSE_Downloader-1.1.1-darwin-arm64.zip.sha256
+```
+
+**Intel Macs:** no prebuilt build. Run from source — see
+[UPGRADE.md](https://github.com/pparesh25/NSE_BSE_Downloader/blob/v1.1.1/UPGRADE.md).
+
+### First launch
+
+These builds are not signed with a paid developer certificate, so both systems will
+warn you once. This is expected.
+
+- **macOS** — "cannot be opened because it is from an unidentified developer."
+  **Right-click** (or Control-click) the app → **Open** → **Open**. Once only.
+- **Windows** — "Windows protected your PC." **More info** → **Run anyway**.
+- **Linux** — nothing unusual.
+
+## What was wrong
+
+A compiled build carries its own copy of OpenSSL. That copy was compiled to look for
+certificate authorities in a directory that exists on the machine that builds the
+release and on no user's machine, and no certificate bundle was included in the
+application. So the packaged application started with nothing to verify against, and
+every HTTPS request to NSE and BSE failed certificate verification.
+
+The downloader treats a certificate failure as final rather than retrying it, which is
+correct — retrying cannot fix a broken trust chain. After a few such failures it also
+paused requests to that host. The visible result was an "SSL certificate issue" for
+every date, then skipped dates, and nothing downloaded.
+
+## What changed
+
+**The application carries its own certificate authorities.** They travel inside the
+build, so a packaged application trusts exactly what a source install trusts, on any
+machine. Certificate verification itself was never weakened and is not weakened now.
+
+**One trust store for every request.** The corporate-action endpoints had been opening
+connections with the default settings instead of the application's own; they now go
+through the same path as everything else.
+
+**Packaging proves it before publishing.** A compiled build must now complete one real
+verified HTTPS request during packaging, and a build with no certificate bundle fails
+the packaging check outright. Every check that existed before this release — checksums,
+archive layout, build provenance, startup, code-signing status — was satisfied by a
+build that could not open a single connection. That gap is what allowed v1.1.0 to ship,
+and it is closed.
+
+## Everything else
+
+Unchanged from [v1.1.0](https://github.com/pparesh25/NSE_BSE_Downloader/releases/tag/v1.1.0).
+Its notes describe the unified date-aware downloads, the nine-column output contracts,
+symbol-wise histories, corporate-action adjustment and the rest of that release, and all
+of it applies here. Data written by v1.1.0 from source needs no migration.
+
+## Requirements
+
+Python 3.10 or newer for source installs. The prebuilt applications need nothing
+installed.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,7 @@ A comprehensive data downloader for NSE and BSE market data with:
 - Smart date management
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __author__ = "NSE/BSE Data Downloader Team"
 __email__ = "support@example.com"
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -2510,12 +2510,14 @@ Built for traders, analysts, and financial professionals.
         except Exception as e:
             self.logger.error(f"Error showing about dialog: {e}")
             # Fallback about text
+            # Deliberately version-free: this path runs when reading the
+            # version failed, and a hardcoded number here goes stale silently.
             fallback_text = """
-NSE/BSE Data Downloader v1.1.0
+NSE/BSE Data Downloader
 
 A comprehensive data downloader for NSE and BSE market data.
             """
-            QMessageBox.about(self, "About NSE/BSE Data Downloader v1.1.0", fallback_text.strip())
+            QMessageBox.about(self, "About NSE/BSE Data Downloader", fallback_text.strip())
 
     def show_donate_dialog(self):
         """Show donate dialog"""

--- a/tests/test_index_and_version.py
+++ b/tests/test_index_and_version.py
@@ -73,12 +73,19 @@ def test_nse_index_allows_blank_optional_ohlc_but_rejects_bad_text():
 
 
 def test_version_history_drives_update_notification():
-    assert get_version() == "1.1.0"
-    notes = VERSION_HISTORY["1.1.0"]
-    assert notes["release_date"] == "2026-08-09"
-    assert any("delivery" in item.lower() for item in notes["features"])
-    assert any("open interest" in item.lower() for item in notes["features"])
-    assert any("calendar" in item.lower() for item in notes["features"])
+    assert get_version() == "1.1.1"
+    notes = VERSION_HISTORY["1.1.1"]
+    assert notes["release_date"] == "2026-08-18"
+    assert any("certificate" in item.lower() for item in notes["features"])
+    assert any("ssl" in item.lower() for item in notes["bug_fixes"])
+
+    # The superseded entry stays, so someone arriving from v1.0.1 still reads
+    # what the 1.1 line actually introduced.
+    superseded = VERSION_HISTORY["1.1.0"]
+    assert superseded["release_date"] == "2026-08-09"
+    assert any("delivery" in item.lower() for item in superseded["features"])
+    assert any("open interest" in item.lower() for item in superseded["features"])
+    assert any("calendar" in item.lower() for item in superseded["features"])
 
     checker = object.__new__(UpdateChecker)
     checker.logger = logging.getLogger("test.update")
@@ -86,13 +93,9 @@ def test_version_history_drives_update_notification():
     parsed = checker._parse_github_version_file(
         Path("version.py").read_text(encoding="utf-8")
     )
-    assert parsed["latest_version"] == "1.1.0"
+    assert parsed["latest_version"] == "1.1.1"
     assert any(
-        "delivery" in item.lower()
-        for item in parsed["changelog"]["features"]
-    )
-    assert any(
-        "calendar" in item.lower()
+        "certificate" in item.lower()
         for item in parsed["changelog"]["features"]
     )
 
@@ -112,7 +115,8 @@ def test_version_metadata_remains_readable_by_v1_0_1_clients():
         re.DOTALL,
     )
 
-    assert version is not None and version.group(1) == "1.1.0"
+    assert version is not None and version.group(1) == "1.1.1"
     assert build_date is not None
     assert history is not None
+    assert '"1.1.1"' in history.group(1)
     assert '"1.1.0"' in history.group(1)

--- a/version.py
+++ b/version.py
@@ -4,9 +4,9 @@ Version Information
 Contains application version and build information.
 """
 
-__version__ = "1.1.0"
-__build_date__ = "2026-08-09"
-__build_number__ = 27
+__version__ = "1.1.1"
+__build_date__ = "2026-08-18"
+__build_number__ = 28
 
 # Verified update artifacts, keyed by "<platform>-<architecture>" exactly as
 # package_release_artifact.py names each release archive.  Release automation
@@ -22,7 +22,7 @@ __build_number__ = 27
 # v1.0.1 clients parse those three by regular expression to discover this
 # release, and tests/test_index_and_version.py fails if that contract breaks.
 __update_artifacts__: dict[str, dict[str, str]] = {
-    # "darwin-arm64": {"url": "https://github.com/.../NSE_BSE_Downloader-1.1.0-darwin-arm64.zip",
+    # "darwin-arm64": {"url": "https://github.com/.../NSE_BSE_Downloader-1.1.1-darwin-arm64.zip",
     #                  "sha256": "<64 hex characters>"},
     # "windows-x64": {...},
     # "linux-x64": {...},
@@ -30,6 +30,19 @@ __update_artifacts__: dict[str, dict[str, str]] = {
 
 # Version history
 VERSION_HISTORY = {
+
+    "1.1.1": {
+        "release_date": "2026-08-18",
+        "features": [
+            "Packaged builds carry their own certificate authorities",
+            "Packaging proves a compiled build can open a verified HTTPS connection"
+        ],
+        "bug_fixes": [
+            "Fixed every download failing with an SSL certificate error in the packaged application",
+            "Fixed the corporate-action endpoints bypassing the application trust store",
+            "Failed a packaging run when no certificate bundle would travel with the build"
+        ]
+    },
 
     "1.1.0": {
         "release_date": "2026-08-09",


### PR DESCRIPTION
Republishes the withdrawn 1.1 line under a new number, now that the trust-store defect is fixed and proved on compiled artifacts (#14, #15).

Version numbers rather than a moved tag, so the history stays honest: 1.1.0 shipped, was withdrawn, 1.1.1 corrects it.

## Changes

- **`version.py`** — `1.1.1`, build date 2026-08-18, build number 28, with its own `VERSION_HISTORY` entry. The 1.1.0 entry stays: someone arriving from 1.0.1 still needs to read what the 1.1 line introduced. `__update_artifacts__` stays empty, keeping the updater notification-only.
- **`README.md` / `UPGRADE.md`** — the "withdrawn" wording is gone and the download table is back, naming the 1.1.1 files. Both carry a short note telling anyone holding a 1.1.0 prebuilt application to replace it, and confirming their data folder is untouched — those builds could not write to it, because they could not download.
- **`RELEASE_NOTES_1.1.1.md`** — user-facing notes. Links point at `blob/v1.1.1/`, not `main`, per the lesson recorded from last time.
- **`PENDING_TASKS.md` §3 closed** with the evidence, and §0 updated.
- **About dialog fallback** no longer hardcodes a version. It runs when reading the version failed, so a number written there goes stale silently — as it already had.

## The v1.0.1 update bridge was re-checked

Not assumed. The edited `version.py` was parsed with the shipped `_parse_github_version_file`: an installed client sees `latest_version 1.1.1` and the 1.1.1 changelog. `tests/test_index_and_version.py` pins that contract and now also pins that the 1.1.0 entry survives.

## Verification

Python 3.13: 415 passed, coverage 77.27%, `ruff` clean, `mypy` clean on 55 files, packaging dry run exit 0, `--smoke-gui` exit 0.
Python 3.10: 415 passed, `--smoke-gui` exit 0.

## Sequence — this PR merges last

Merging is the point of no return: the moment `main/version.py` reads `1.1.1`, every running client announces it. So, in order:

1. This PR open, gates green.
2. Tag `v1.1.1` at this branch head → three-platform build, with `--verify-tls` running on each compiled artifact.
3. Download all six assets, verify each `.sha256`.
4. Rebuild `RELEASE_BUILD_EVIDENCE.md` at the tagged commit.
5. Create the GitHub Release with the six files. Upload the large assets separately — `gh release create` did not finish 198 MB inside ten minutes last time.
6. **Then** merge this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)