### PR TITLE
feat: write diagnostics a user can actually send

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ work is active follows the same safe shutdown path.
 
 Files are stored under `~/NSE_BSE_Data/` by default.
 
+If something goes wrong, **Help → Open Log Folder** opens
+`~/.nse_bse_downloader/logs/`. Each run records the application version,
+platform and certificate status at the top, so attaching the log to an issue is
+usually enough to identify the build. The files are capped and rotated, and
+nothing is written into your data folder.
+
 ## Output contracts
 
 NSE/BSE Equity and SME:

--- a/docs/engineering/CODE_DEFECT_REMEDIATION_PLAN.md
+++ b/docs/engineering/CODE_DEFECT_REMEDIATION_PLAN.md
@@ -1402,11 +1402,28 @@ self-consistent?" is currently unanswerable without mutating it.
       every era. Settle the naming decision (PENDING_TASKS §1) **before** release;
       changing it later forces a migration of published files.
 
-### 4.3 Diagnostics — effort S
+### 4.3 Diagnostics — effort S — **done 2026-08-19**
 
-- [ ] `RotatingFileHandler` in `run_gui_mode` and a Help → "Open Log Folder" action.
-      There is no logging configuration anywhere; a packaged binary produces zero
-      diagnostics.
+- [x] `RotatingFileHandler` and a Help → "Open Log Folder" action. There was no
+      logging configuration anywhere, so a packaged binary produced zero
+      diagnostics: every `logger.info` went to a handler that was never
+      installed, and only Python's last-resort handler put warnings on a console
+      a windowed application does not have.
+
+Implemented in `src/utils/logging_setup.py`, configured from `main()` so the
+repair commands are covered too, not only the GUI. Logs go to
+`~/.nse_bse_downloader/logs/`, bounded at 2 MB with five backups, and never
+under the data root. The console keeps `WARNING` and above; the file keeps
+`INFO`, so a terminal stays readable while the detail survives.
+
+Every run starts by recording the version, build date, platform, Python version,
+whether this is a packaged build, and which certificate bundle it loaded — so a
+log file attached to an issue identifies itself without anyone having to ask.
+That last line is the one whose absence withdrew v1.1.0.
+
+The cost of not having this was measured: diagnosing that certificate defect
+meant running the packaged binary from a terminal to capture stderr, which is
+not something a user can be asked to do.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ Usage:
 
 import sys
 import argparse
+import logging
 from pathlib import Path
 
 MINIMUM_PYTHON = (3, 10)
@@ -362,6 +363,14 @@ def main():
     """Main entry point"""
     parser = setup_argument_parser()
     args = parser.parse_args()
+
+    # Before anything that can fail, so whatever happens next is recorded.
+    from src.utils.logging_setup import configure_logging, log_environment
+
+    log_path = configure_logging()
+    log_environment()
+    if log_path is not None:
+        logging.getLogger(__name__).info(f"Logging to {log_path}")
 
     if args.verify_tls:
         return run_tls_check()

--- a/runtime_paths.py
+++ b/runtime_paths.py
@@ -24,3 +24,20 @@ def default_config_path() -> Path:
     """Return the bundled default configuration path."""
 
     return resource_path("config.yaml")
+
+
+def user_state_dir() -> Path:
+    """Return the writable per-user directory for preferences and diagnostics.
+
+    Deliberately not the data root.  Everything under it is regenerable; the
+    data root holds years of downloaded market history and nothing here may
+    grow inside it.
+    """
+
+    return Path.home() / ".nse_bse_downloader"
+
+
+def log_directory() -> Path:
+    """Return the directory application logs are written to."""
+
+    return user_state_dir() / "logs"

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1314,9 +1314,43 @@ class MainWindow(QMainWindow):
         )
         help_menu.addAction(check_update_action)
 
+        open_logs_action = QAction('Open Log Folder', self)
+        open_logs_action.triggered.connect(self.open_log_folder)
+        help_menu.addAction(open_logs_action)
+
         about_action = QAction('About', self)
         about_action.triggered.connect(self.show_about)
         help_menu.addAction(about_action)
+
+    def open_log_folder(self) -> None:
+        """Open the folder holding the log files, for attaching to a report.
+
+        A packaged application has no console, so this is the only way a user
+        can hand over what the application recorded.  The folder is opened
+        rather than the file itself, because the rotated copies next to it are
+        usually the interesting ones after a crash.
+        """
+
+        from PySide6.QtCore import QUrl
+        from PySide6.QtGui import QDesktopServices
+
+        from runtime_paths import log_directory
+
+        folder = log_directory()
+        try:
+            folder.mkdir(parents=True, exist_ok=True)
+        except OSError as error:
+            QMessageBox.warning(
+                self,
+                "Log Folder",
+                f"The log folder could not be created:\n\n{folder}\n\n{error}",
+            )
+            return
+
+        if not QDesktopServices.openUrl(QUrl.fromLocalFile(str(folder))):
+            QMessageBox.information(
+                self, "Log Folder", f"Logs are written to:\n\n{folder}"
+            )
 
     def create_exchange_selection(self) -> QGroupBox:
         """Create exchange selection area"""

--- a/src/utils/logging_setup.py
+++ b/src/utils/logging_setup.py
@@ -1,0 +1,110 @@
+"""Where the application's diagnostics go, and what they say.
+
+Until this existed there was no logging configuration anywhere, so a packaged
+build produced nothing a user could send: every ``logger.info`` went to a
+handler that was never installed, and only Python's last-resort handler put
+warnings on a console a windowed application does not have.  Diagnosing the
+v1.1.1 certificate defect meant running the packaged binary from a terminal to
+capture stderr, which is not something a user can be asked to do.
+
+Logs are written under the per-user state directory, never under the data root:
+the data root holds years of downloaded market history, and a log file has no
+business growing inside it.
+"""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import platform
+import sys
+from pathlib import Path
+from typing import Optional
+
+from runtime_paths import log_directory
+
+#: Roughly a dozen long runs before the oldest is dropped.  Large enough to
+#: cover a multi-day backfill, bounded so it can never quietly fill a disk.
+MAX_LOG_BYTES = 2 * 1024 * 1024
+BACKUP_COUNT = 5
+LOG_FILENAME = "nse_bse_downloader.log"
+
+_FILE_FORMAT = "%(asctime)s %(levelname)-8s %(name)s: %(message)s"
+_CONSOLE_FORMAT = "%(levelname)s: %(message)s"
+
+#: Marks the handlers this module installs, so configuring twice replaces them
+#: instead of writing every record two or three times.
+_MARKER = "_nse_bse_downloader_handler"
+
+
+def configure_logging(
+    *,
+    console_level: int = logging.WARNING,
+    file_level: int = logging.INFO,
+    directory: Optional[Path] = None,
+) -> Optional[Path]:
+    """Install the file and console handlers and return the log file path.
+
+    Returns ``None`` when no file could be opened -- a read-only home, a full
+    disk, a permission the user does not have.  Console logging is still set up
+    in that case: losing diagnostics is bad, but refusing to start the
+    application because a log file could not be created would be worse.
+    """
+
+    root = logging.getLogger()
+    root.setLevel(min(console_level, file_level))
+    for handler in [h for h in root.handlers if getattr(h, _MARKER, False)]:
+        root.removeHandler(handler)
+        handler.close()
+
+    console = logging.StreamHandler(sys.stderr)
+    console.setLevel(console_level)
+    console.setFormatter(logging.Formatter(_CONSOLE_FORMAT))
+    setattr(console, _MARKER, True)
+    root.addHandler(console)
+
+    target = directory if directory is not None else log_directory()
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+        path = target / LOG_FILENAME
+        file_handler = logging.handlers.RotatingFileHandler(
+            path,
+            maxBytes=MAX_LOG_BYTES,
+            backupCount=BACKUP_COUNT,
+            encoding="utf-8",
+        )
+    except OSError as error:
+        root.warning(f"Could not open a log file under {target}: {error}")
+        return None
+
+    file_handler.setLevel(file_level)
+    file_handler.setFormatter(logging.Formatter(_FILE_FORMAT))
+    setattr(file_handler, _MARKER, True)
+    root.addHandler(file_handler)
+    return path
+
+
+def log_environment(logger: Optional[logging.Logger] = None) -> None:
+    """Record what this build is, at the top of every run.
+
+    A log file arriving on an issue should identify itself without anyone
+    having to ask which build produced it -- including whether it is a packaged
+    artifact and whether it carries the certificate bundle whose absence
+    withdrew v1.1.0.
+    """
+
+    from app_metadata import PRODUCT_NAME
+    from src.utils.tls import certificate_bundle_path
+    from version import __build_date__, get_version
+
+    log = logger or logging.getLogger(__name__)
+    packaged = getattr(sys, "frozen", False) or "__compiled__" in globals()
+    bundle = certificate_bundle_path()
+
+    log.info(f"{PRODUCT_NAME} {get_version()} (build {__build_date__})")
+    log.info(
+        f"Python {platform.python_version()} on {platform.system()} "
+        f"{platform.release()} {platform.machine()}"
+    )
+    log.info(f"Packaged build: {packaged}")
+    log.info(f"Certificate bundle: {bundle if bundle is not None else 'system default'}")

--- a/tests/test_logging_diagnostics.py
+++ b/tests/test_logging_diagnostics.py
@@ -1,0 +1,168 @@
+"""Diagnostics a user can actually send.
+
+A packaged build has no console, so anything it fails to write down is lost.
+These tests pin the two properties that matter: something is written, and it is
+never written into the data root.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+import runtime_paths
+from src.utils import logging_setup
+from src.utils.logging_setup import (
+    BACKUP_COUNT,
+    LOG_FILENAME,
+    MAX_LOG_BYTES,
+    configure_logging,
+    log_environment,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_handlers():
+    root = logging.getLogger()
+    saved, level = list(root.handlers), root.level
+    yield
+    for handler in [h for h in root.handlers if h not in saved]:
+        root.removeHandler(handler)
+        handler.close()
+    for handler in saved:
+        if handler not in root.handlers:
+            root.addHandler(handler)
+    root.setLevel(level)
+
+
+def _our_handlers():
+    return [
+        h for h in logging.getLogger().handlers
+        if getattr(h, logging_setup._MARKER, False)
+    ]
+
+
+def test_logging_writes_a_file_under_the_user_state_directory(tmp_path):
+    path = configure_logging(directory=tmp_path)
+    assert path == tmp_path / LOG_FILENAME
+
+    logging.getLogger("test.diagnostics").info("a recorded message")
+    assert "a recorded message" in path.read_text(encoding="utf-8")
+
+
+def test_the_log_file_is_bounded(tmp_path):
+    configure_logging(directory=tmp_path)
+    rotating = [h for h in _our_handlers() if hasattr(h, "maxBytes")]
+    assert len(rotating) == 1
+    assert rotating[0].maxBytes == MAX_LOG_BYTES
+    assert rotating[0].backupCount == BACKUP_COUNT
+
+
+def test_configuring_twice_does_not_duplicate_every_record(tmp_path):
+    configure_logging(directory=tmp_path)
+    configure_logging(directory=tmp_path)
+
+    logging.getLogger("test.diagnostics").warning("said once")
+    written = (tmp_path / LOG_FILENAME).read_text(encoding="utf-8")
+    assert written.count("said once") == 1
+    assert len(_our_handlers()) == 2  # one console, one file
+
+
+def test_the_console_stays_quiet_below_warning(tmp_path, capsys):
+    configure_logging(directory=tmp_path)
+    logger = logging.getLogger("test.diagnostics")
+    logger.info("routine detail")
+    logger.warning("worth interrupting for")
+
+    captured = capsys.readouterr().err
+    assert "routine detail" not in captured
+    assert "worth interrupting for" in captured
+    # The detail is not lost, it is just not shouted about.
+    assert "routine detail" in (tmp_path / LOG_FILENAME).read_text(encoding="utf-8")
+
+
+def test_an_unwritable_location_does_not_stop_the_application(tmp_path):
+    blocked = tmp_path / "not-a-directory"
+    blocked.write_text("", encoding="utf-8")
+
+    path = configure_logging(directory=blocked / "logs")
+
+    assert path is None
+    assert _our_handlers(), "console logging must survive a failed log file"
+
+
+def test_logs_never_go_near_the_data_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    data_root = tmp_path / "NSE_BSE_Data"
+    data_root.mkdir()
+
+    path = configure_logging()
+
+    assert path is not None
+    assert data_root not in path.parents
+    assert path.parent == runtime_paths.log_directory()
+    assert list(data_root.iterdir()) == []
+
+
+def test_the_log_identifies_the_build_that_wrote_it(tmp_path):
+    path = configure_logging(directory=tmp_path)
+    log_environment()
+
+    written = path.read_text(encoding="utf-8")
+    from version import get_version
+
+    assert get_version() in written
+    assert "Packaged build:" in written
+    # The absence of this line is what withdrew v1.1.0.
+    assert "Certificate bundle:" in written
+
+
+def test_help_menu_can_open_the_log_folder(tmp_path, monkeypatch):
+    from PySide6.QtGui import QDesktopServices
+    from PySide6.QtWidgets import QApplication
+
+    from src.core.config import Config
+    from src.gui.main_window import MainWindow
+
+    QApplication.instance() or QApplication([])
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+
+    opened = []
+    monkeypatch.setattr(
+        QDesktopServices,
+        "openUrl",
+        lambda url: bool(opened.append(url.toLocalFile())) or True,
+    )
+
+    config = Config("config.yaml")
+    config.base_data_path = tmp_path / "data"
+    window = MainWindow(config)
+    try:
+        # Kept in real variables rather than a generator: PySide6 drops the
+        # Python wrapper for a QMenu obtained inside a discarded generator, and
+        # the next call on it raises "already deleted".
+        help_menu = None
+        for item in window.menuBar().actions():
+            if item.text() == "Help":
+                help_menu = item.menu()
+        assert help_menu is not None
+
+        open_logs = None
+        for action in help_menu.actions():
+            if action.text() == "Open Log Folder":
+                open_logs = action
+        assert open_logs is not None
+
+        open_logs.trigger()
+
+        assert opened == [str(runtime_paths.log_directory())]
+        assert runtime_paths.log_directory().is_dir()
+        # The window creates its data root, as it always does; what must never
+        # appear there is a log file.
+        assert list((tmp_path / "data").rglob("*.log")) == []
+    finally:
+        window.close()


### PR DESCRIPTION
Closes **Phase 4.3** of `CODE_DEFECT_REMEDIATION_PLAN.md`.

## The problem

There was no logging configuration anywhere in the project — no `basicConfig`, no handler, nothing. Every `logger.info` in `src/` went to a handler that was never installed, and only Python's last-resort handler put warnings on a console that a windowed application does not have. A packaged build produced **nothing**.

The cost was measured this month: diagnosing the certificate defect that withdrew v1.1.0 meant running the packaged binary from a terminal to capture stderr. That is not something a user can be asked to do.

## What this adds

- **`src/utils/logging_setup.py`** — a rotating file handler plus a console handler, configured from `main()` so the long-running repair commands are covered too, not only the GUI.
- **Location:** `~/.nse_bse_downloader/logs/`, beside the preferences and deliberately **not** under the data root — that folder holds years of downloaded history and a log file has no business growing inside it. A test pins this.
- **Bounded:** 2 MB × 5 backups, so it cannot quietly fill a disk.
- **Levels:** console keeps `WARNING` and above, file keeps `INFO` — a terminal stays readable while the detail survives.
- **Fails soft:** if the file cannot be opened (read-only home, full disk), console logging is still installed and the run continues. Losing diagnostics is bad; refusing to start over a log file would be worse.
- **Every run identifies itself:** version, build date, platform, Python version, whether this is a packaged build, and which certificate bundle loaded. A log attached to an issue then answers "which build is this?" on its own — and that last line is the one whose absence withdrew v1.1.0.
- **Help → Open Log Folder**, which opens the folder rather than the file: after a crash the rotated copies beside it are usually the interesting ones.

## Tests

8 new, including: the file is written and bounded; configuring twice does not duplicate every record; the console stays quiet below `WARNING` while the detail still reaches the file; an unwritable location does not stop the application; **no `.log` ever appears under the data root**; the banner names the build; and the Help action opens the log directory.

## Verification

Python 3.13: 423 passed (was 415), coverage 77.42%, `ruff` clean, `mypy` clean on 56 files, packaging dry run exit 0, `--smoke-gui` exit 0.
Python 3.10: 423 passed, `--smoke-gui` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)