### PR TITLE
feat: a read-only --audit command (remediation plan 4.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ A desktop downloader that turns legacy and current NSE/BSE reports into one stab
 - Split, consolidation and equity-bonus adjustments on pre-ex-date symbol
   prices and share counts, so price and turnover stay continuous.
 - Pending delivery retry, atomic file replacement and corporate-action audit state.
+- A read-only `--audit` command that verifies digests, coverage, row counts and
+  symbol histories without changing a single byte of the data folder.
 - Staged per-date publication with deterministic SME/Index combination.
 - Calendar-based historical/custom date ranges with automatic mode retained.
 - Individually collapsible Exchange, Date, Options, Progress and Status panels.
@@ -209,6 +211,39 @@ uses the current append preferences and persisted EQ/SME/Index components.
 Existing files remain in place when validation or transaction recovery cannot
 be completed safely.
 
+## Checking the database without changing it
+
+The rebuild commands above repair; `--audit` only looks. It answers "is this
+database complete and self-consistent?" and writes nothing at all, so it is
+safe to run at any time, including while a download is in progress.
+
+```bash
+python main.py --audit                # the whole data folder
+python main.py --audit NSE_EQ BSE_EQ  # only these segments
+```
+
+It reports:
+
+- every sha256 the pipeline recorded, checked against the file on disk —
+  published files, reconciliation components, combined outputs and the
+  `.state/raw` snapshots;
+- coverage from `base_start_date` to the most recent session the exchanges
+  have published, so a truncated head and a stale tail are both visible, with
+  trading holidays taken from the offline calendar rather than guessed;
+- row counts against what was recorded and against neighbouring sessions, which
+  is the only plausibility check available for files written before the
+  pipeline database existed;
+- every `SYMBOLS/*.txt` history cross-checked against the raw snapshots, in
+  both directions;
+- orphans: components and snapshots for dates that were never published,
+  metadata without its snapshot, temporary files from writes that did not
+  finish, and registry entries naming files that do not exist.
+
+Exit codes are `0` for a clean database, `1` when there are findings, and `2`
+when the audit itself could not run. Notices — data older than the pipeline
+database, a tail you have not downloaded yet, the older symbol-file column set
+— are shown but do not fail the command.
+
 ## Date-aware report support
 
 The application automatically selects the proper official source:
@@ -280,6 +315,11 @@ revisions and rebuilds from checksummed raw snapshots. Lifecycle coverage also
 checks cooperative cancellation/window close, settings precedence, skipped
 updates, IST boundaries, official-calendar parsing, TTL refresh and stale fallback.
 
+The `--audit` tests cover every finding it can report and, separately, the
+promise that it reports them without writing: one test fingerprints every path,
+mtime, size and content digest under a data root around a full run and requires
+them to be identical afterwards.
+
 GitHub Actions runs the suite on Python 3.10 and 3.13 and fails below 70%
 coverage. Ruff, mypy and a no-build Nuitka command validation are separate
 release gates. The equivalent local commands are:
@@ -292,7 +332,7 @@ python build_nuitka_cross_platform.py --target linux
 ```
 They also verify bundle-root config/QR lookup, compiled-module version detection,
 platform-specific Nuitka command generation and the default no-build guard. The
-strict project mypy configuration currently passes all 45 source files.
+strict project mypy configuration currently passes all 56 source files.
 
 ## Version history
 

--- a/docs/engineering/CODE_DEFECT_REMEDIATION_PLAN.md
+++ b/docs/engineering/CODE_DEFECT_REMEDIATION_PLAN.md
@@ -1364,24 +1364,106 @@ break a setup that works today; only a genuine `EACCES`/`EAGAIN` means "held".
 
 ## Phase 4 — Make the database verifiable
 
-### 4.1 A read-only `--audit` command — effort M
+### 4.1 A read-only `--audit` command — effort M — **done 2026-08-20**
 
-sha256 digests are written into the manifest and **never read back**. The only checksum
-verification in the codebase is for raw snapshots and the update downloader.
+sha256 digests were written into the manifest and **never read back**. The only checksum
+verification in the codebase was for raw snapshots and the update downloader.
 `get_missing_file_dates` computes expected dates only *between* the first and last
-existing filename, so a truncated head or stale tail is invisible. Nothing enumerates
-`<EX>/SYMBOLS/` at all. The only repair tooling is the destructive `--rebuild-*`.
+existing filename, so a truncated head or stale tail was invisible. Nothing enumerated
+`<EX>/SYMBOLS/` at all. The only repair tooling was the destructive `--rebuild-*`.
 
 For a database intended to accumulate over years and be traded off, "is it complete and
-self-consistent?" is currently unanswerable without mutating it.
+self-consistent?" was unanswerable without mutating it.
 
-- [ ] Verify every manifest digest against disk
-- [ ] Per-segment expected-row-count bands
-- [ ] Head/tail gap detection against `base_start_date`, not the first filename
-- [ ] `SYMBOLS/*.txt` date coverage cross-checked against the checksummed `.state/raw`
+- [x] Verify every manifest digest against disk
+- [x] Per-segment expected-row-count bands
+- [x] Head/tail gap detection against `base_start_date`, not the first filename
+- [x] `SYMBOLS/*.txt` date coverage cross-checked against the checksummed `.state/raw`
       snapshots
-- [ ] Orphan detection
-- [ ] Read-only: the command must never write
+- [x] Orphan detection
+- [x] Read-only: the command must never write
+
+Implemented in `src/services/audit_service.py`, driven by `python main.py --audit
+[EXCHANGE_SEGMENT ...]`. Exit codes are three-valued — `0` clean, `1` findings, `2` the
+audit could not look — because a script that treated the last two alike would report a
+broken audit as clean data.
+
+#### Read-only had to be built, not merely intended
+
+Four ordinary routes into a data root write before they read, so none of them could be
+used: `Config.get_data_path` creates the folder it is asked about (`resolve_data_path`
+was split out of it), `DataManager.__init__` creates the whole folder structure (the
+filename contract moved to `DAILY_FILE_PATTERNS` at module scope), `PipelineManifest`
+initialises its SQLite schema and imports the legacy JSON in its constructor, and
+`VersionedJSONStore.read` copies anything it cannot parse into `.state/quarantine`. A
+record this command cannot parse is reported, not moved.
+
+SQLite's own `mode=ro` is not read-only either, which measuring found and reading would
+not have: opening the real data root that way left `pipeline_state.sqlite3-shm`
+rewritten, because a WAL database needs its shared-memory index and a read-only
+*connection* still creates and stamps it. On a genuinely read-only medium it would fail
+outright. `ReadOnlyPipelineStore` copies the database to a temporary directory outside
+the data root and opens the copy.
+
+`tests/test_audit_command.py` fingerprints every path, mtime, size and content digest
+under a data root around a full run. Reverting the SQLite copy to `mode=ro` fails it.
+
+#### The false positive that would have made it useless
+
+For NSE EQ the daily stage records the *component's* digest under `sha256`, and the
+combined stage appends SME and Index rows to the published file afterwards, recording
+its own digest. Comparing the daily digest against that file would have reported every
+combined date as corrupt. The component and the combined output are each checked against
+their own digest instead; both halves are pinned by tests.
+
+The same distinction governs row counts: `_recorded_rows` prefers the combined stage's
+count exactly as `published_row_counts` does, or a deferred EQ file would look 600 rows
+short of its record every day.
+
+#### Coverage is judged offline, and declines what it cannot know
+
+The calendar comes from the saved holiday cache first and the bundled 2013–2026 calendar
+second. `HolidayManager.is_holiday` fetches a year it does not have, and an audit that
+hangs trying to reach NSE cannot help diagnose the TLS failure that withdrew v1.1.0.
+`HolidayManager.cached_calendar` was added for this. A year neither source covers is
+declined rather than guessed — assuming it had no holidays would report every Diwali in
+it as a missing session — and the report names those years.
+
+A stale tail is a notice rather than a warning. Freshness is the owner's decision, and a
+command that failed because he had not downloaded today is one he would stop running.
+
+#### Symbol coverage without loading the whole database
+
+Coverage is held as one bit per snapshot date. A finished multi-year backfill holds tens
+of millions of (symbol, date) pairs; a bitmask keeps a 4,000-symbol, 7,500-session
+expectation inside a few megabytes. A raw row is resolved to its file by identity first
+and ticker second, the way the store itself does it — resolving by ticker alone would
+look for the file a rename had already merged away, and report a healthy database as
+missing thousands of histories.
+
+#### Measured on the owner's real data root, 2026-08-20
+
+`~/NSE_BSE_Data`, 8,615 entries:
+
+- 308 recorded digests verified against disk across six segments, all matching;
+- 84 raw snapshots verified against their own metadata, all matching;
+- 8,096 symbol histories reconciled against those snapshots — 208,555 (symbol, date)
+  pairs — with no gap in either direction;
+- 12 findings, all true: six head gaps of 234 trading days each (the database starts
+  2026-07-01, `base_start_date` is 2025-07-15) and six stale tails of 8 sessions;
+- 2.8 seconds for the whole run;
+- the tree byte-for-byte and stat-for-stat unchanged afterwards.
+
+Two defects were found by running it rather than by reading it: the SQLite `-shm` write
+above, and `with_suffix` being unable to undo a two-part suffix, which turned
+`2026-07-01.csv.meta.json` into `2026-07-01.csv.csv` and reported all 84 healthy
+snapshots as widowed.
+
+#### What it does not do
+
+The per-segment earliest-available floor belongs to 4.2, so the head-gap check measures
+against `base_start_date` for every segment. Until 4.2 lands, a segment the exchange
+simply did not publish that far back will report a head gap that no download can close.
 
 ### 4.2 Missing fields and metadata — effort M
 
@@ -1465,7 +1547,9 @@ Phase 2  make it finish          ← done.  2.1 memory ceiling gone; 2.2 write v
 Phase 3  stop writing wrong data ← done.  3.1 parser, 3.2 volume, 3.3 identity,
                                    3.4 size/value gates, 3.5 one writer per root
    ↓
-Phase 4  verifiability           ← --audit answers "can I trust this?"
+Phase 4  verifiability           ← 4.1 done: --audit answers "can I trust
+                                   this?" without changing the answer.  4.2
+                                   missing fields still open; 4.3 done
    ↓
 Phase 5  storage model           ← the durable fix, built on a correct base
 ```

--- a/main.py
+++ b/main.py
@@ -87,6 +87,8 @@ Examples:
     python main.py --rebuild-symbol NSE RELIANCE
     python main.py --rebuild-exchange BSE
     python main.py --rebuild-combined NSE 2026-07-31
+    python main.py --audit                # verify the database, change nothing
+    python main.py --audit NSE_EQ BSE_EQ  # verify only these segments
         """
     )
 
@@ -135,8 +137,43 @@ Examples:
         metavar=("EXCHANGE", "YYYY-MM-DD"),
         help="Rebuild one deterministic EQ+SME/Index output from components",
     )
+    # In the same mutually exclusive group as the repairs even though it
+    # repairs nothing: asking a question about the database while rewriting it
+    # would not answer the question.  ``default=None`` distinguishes "not
+    # asked" from ``--audit`` with no segments, which is an empty list.
+    repair.add_argument(
+        "--audit",
+        nargs="*",
+        default=None,
+        metavar="EXCHANGE_SEGMENT",
+        help=(
+            "Verify the data root against its own records without writing "
+            "anything; optionally limit it to named segments, e.g. NSE_EQ"
+        ),
+    )
 
     return parser
+
+
+def run_audit_mode(config_path: str, segments) -> int:
+    """Report on the data root without changing it.
+
+    Exit codes are three-valued on purpose, because "the database has a
+    problem" and "the audit could not look" are different answers and a
+    script that treats them alike would report a broken audit as clean data.
+    """
+
+    from src.services.audit_service import DatabaseAudit
+
+    try:
+        config = Config(config_path)
+        report = DatabaseAudit(config, segments).run()
+    except Exception as error:
+        print(f"Audit could not run: {error}")
+        return 2
+
+    print(report.render())
+    return 1 if report.failed else 0
 
 
 def run_rebuild_mode(config_path: str, args) -> int:
@@ -382,6 +419,9 @@ def main():
         return 1
 
     try:
+        if args.audit is not None:
+            return run_audit_mode(str(config_path), args.audit)
+
         if (
             args.rebuild_symbol
             or args.rebuild_exchange

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -286,6 +286,31 @@ class Config:
 
         return self._exchange_configs[exchange][segment]
 
+    def resolve_data_path(self, exchange: str, segment: str) -> Path:
+        """Return the folder for one segment without creating anything.
+
+        ``get_data_path`` creates the folder as a side effect of being asked
+        where it is, which a read-only caller such as ``--audit`` must not do:
+        a report is only evidence about the database if producing it did not
+        change the database.
+
+        Args:
+            exchange: Exchange name
+            segment: Segment name
+
+        Returns:
+            Path object for data storage, which may not exist
+        """
+        exchange_paths = self._config_data.get('data_paths', {}).get('exchanges', {})
+
+        if exchange in exchange_paths and segment in exchange_paths[exchange]:
+            relative_path = exchange_paths[exchange][segment]
+        else:
+            # Default path structure
+            relative_path = f"{exchange}/{segment}"
+
+        return self.base_data_path / relative_path
+
     def get_data_path(self, exchange: str, segment: str) -> Path:
         """
         Get data storage path for specific exchange and segment
@@ -297,15 +322,7 @@ class Config:
         Returns:
             Path object for data storage
         """
-        exchange_paths = self._config_data.get('data_paths', {}).get('exchanges', {})
-
-        if exchange in exchange_paths and segment in exchange_paths[exchange]:
-            relative_path = exchange_paths[exchange][segment]
-        else:
-            # Default path structure
-            relative_path = f"{exchange}/{segment}"
-
-        data_path = self.base_data_path / relative_path
+        data_path = self.resolve_data_path(exchange, segment)
         data_path.mkdir(parents=True, exist_ok=True)
 
         return data_path

--- a/src/core/data_manager.py
+++ b/src/core/data_manager.py
@@ -20,6 +20,20 @@ from .exceptions import DataProcessingError, FileOperationError, DateRangeError
 from ..utils.date_utils import DateUtils
 
 
+#: The published filename contract, one pattern per exchange segment.  Kept at
+#: module scope so a read-only caller such as ``--audit`` can recognise a
+#: published file without constructing a ``DataManager``, whose ``__init__``
+#: creates the folder structure.
+DAILY_FILE_PATTERNS = {
+    'NSE_EQ': r'(\d{4}-\d{2}-\d{2})-NSE-EQ\.(?:txt|csv)',
+    'NSE_FO': r'(\d{4}-\d{2}-\d{2})-NSE-FO\.(?:txt|csv)',
+    'NSE_SME': r'(\d{4}-\d{2}-\d{2})-NSE-SME\.(?:txt|csv)',
+    'NSE_INDEX': r'(\d{4}-\d{2}-\d{2})-NSE-INDEX\.(?:txt|csv)',
+    'BSE_EQ': r'(\d{4}-\d{2}-\d{2})-BSE-EQ\.(?:txt|csv)',
+    'BSE_INDEX': r'(\d{4}-\d{2}-\d{2})-BSE-INDEX\.(?:txt|csv)',
+}
+
+
 class DataManager:
     """
     Centralized data management system
@@ -41,14 +55,7 @@ class DataManager:
         self._expected_row_cache: Dict[tuple[str, str], Dict[date, int]] = {}
 
         # Date patterns for different exchanges
-        self.date_patterns = {
-            'NSE_EQ': r'(\d{4}-\d{2}-\d{2})-NSE-EQ\.(?:txt|csv)',
-            'NSE_FO': r'(\d{4}-\d{2}-\d{2})-NSE-FO\.(?:txt|csv)',
-            'NSE_SME': r'(\d{4}-\d{2}-\d{2})-NSE-SME\.(?:txt|csv)',
-            'NSE_INDEX': r'(\d{4}-\d{2}-\d{2})-NSE-INDEX\.(?:txt|csv)',
-            'BSE_EQ': r'(\d{4}-\d{2}-\d{2})-BSE-EQ\.(?:txt|csv)',
-            'BSE_INDEX': r'(\d{4}-\d{2}-\d{2})-BSE-INDEX\.(?:txt|csv)',
-        }
+        self.date_patterns = dict(DAILY_FILE_PATTERNS)
         self._ensure_folder_structure()
 
     def is_trading_day(

--- a/src/services/audit_service.py
+++ b/src/services/audit_service.py
@@ -24,6 +24,7 @@ none of the ordinary routes into the data root are used here:
 
 from __future__ import annotations
 
+import csv
 import hashlib
 import json
 import os
@@ -39,9 +40,17 @@ from ..core.config import Config
 from ..core.data_manager import DAILY_FILE_PATTERNS
 from ..utils import holiday_calendar
 from ..utils.date_utils import DateUtils
-from .canonical_data import BAND_SESSIONS, row_count_band_error
+from .canonical_data import (
+    BAND_SESSIONS,
+    LEGACY_SYMBOL_HISTORY_COLUMNS,
+    SYMBOL_HISTORY_COLUMNS,
+    row_count_band_error,
+    valid_isin,
+    valid_security_id,
+)
 from .instance_lock import SingleInstanceLock
 from .pipeline_sqlite import ReadOnlyPipelineStore
+from .symbol_history import SymbolHistoryStore
 
 ERROR = "error"
 WARNING = "warning"
@@ -66,6 +75,20 @@ BAND_MAX_DISTANCE_DAYS = 180
 
 #: Read size for the single pass that produces both a digest and a row count.
 _READ_BLOCK = 1024 * 1024
+
+#: How many individual dates or filenames one aggregated finding names before
+#: it falls back to a count.  A finding nobody can read is not a finding.
+_LISTED = 5
+
+
+def _describe(values: Sequence[Any], total: Optional[int] = None) -> str:
+    """Name the first few of ``values`` and count the rest."""
+
+    total = len(values) if total is None else total
+    listed = ", ".join(str(value) for value in values[:_LISTED])
+    if total > len(values[:_LISTED]):
+        listed += f", and {total - len(values[:_LISTED])} more"
+    return listed
 
 
 @dataclass(frozen=True)
@@ -227,11 +250,29 @@ class SegmentSummary:
 
 
 @dataclass
+class SymbolSummary:
+    """What the symbol cross-check looked at for one exchange."""
+
+    exchange: str
+    histories: int = 0
+    snapshots: int = 0
+    pairs: int = 0
+
+    def render(self) -> str:
+        return (
+            f"  {self.exchange + ' SYMBOLS':<10} {self.histories:>6} history "
+            f"files, {self.snapshots:>6} raw snapshots, {self.pairs:>7} "
+            "(symbol, date) pairs checked"
+        )
+
+
+@dataclass
 class AuditReport:
     """Everything one ``--audit`` run established."""
 
     base_data_path: Path
     summaries: tuple[SegmentSummary, ...] = ()
+    symbols: tuple[SymbolSummary, ...] = ()
     findings: tuple[AuditFinding, ...] = ()
     notes: tuple[str, ...] = ()
 
@@ -256,6 +297,8 @@ class AuditReport:
             lines.append("")
         for summary in self.summaries:
             lines.append(summary.render())
+        for symbol_summary in self.symbols:
+            lines.append(symbol_summary.render())
         lines.append("")
 
         if not self.findings:
@@ -304,6 +347,7 @@ class DatabaseAudit:
         self._notes: list[str] = []
         self._relocated_reported = False
         self._unknown_calendar_years: set[int] = set()
+        self._registry_cache: Optional[dict[str, Any]] = None
         # One read per file, however many checks want to look at it.
         self._measurements: dict[Path, Optional[FileMeasurement]] = {}
 
@@ -952,6 +996,491 @@ class DatabaseAudit:
                     path=published[target_date],
                 )
 
+    # ----------------------------------------------------------- symbol files
+
+    def _registry(self) -> dict[str, Any]:
+        """The symbol registry, read without the store's quarantine behaviour."""
+
+        if self._registry_cache is not None:
+            return self._registry_cache
+        empty: dict[str, Any] = {
+            "exchanges": {}, "files": {}, "identities": {}
+        }
+        path = self.base_data_path / ".state" / "symbol_registry.json"
+        if not path.is_file():
+            self._registry_cache = empty
+            return empty
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError("the registry must be an object")
+        except (OSError, ValueError) as error:
+            self._add(
+                ERROR,
+                "unreadable-registry",
+                f"the symbol registry could not be read: {error}",
+                path=path,
+            )
+            self._registry_cache = empty
+            return empty
+        for section in ("exchanges", "files", "identities"):
+            if not isinstance(data.get(section), dict):
+                data[section] = {}
+        self._registry_cache = data
+        return data
+
+    def _snapshot_paths(self, exchange: str) -> list[Path]:
+        """Every checksummed raw snapshot for one exchange, oldest first."""
+
+        root = self.base_data_path / ".state" / "raw" / exchange
+        if not root.is_dir():
+            return []
+        paths = [
+            path
+            for segment in sorted(root.iterdir()) if segment.is_dir()
+            for path in sorted(segment.glob("*.csv"))
+        ]
+        return sorted(paths, key=lambda path: path.stem)
+
+    def _snapshot_filename(
+        self,
+        exchange: str,
+        registry: dict[str, Any],
+        row: Sequence[str],
+        columns: dict[str, int],
+    ) -> Optional[str]:
+        """The symbol file one raw row belongs in, resolved as the store does.
+
+        Identity first, then the ticker.  A renamed security keeps its file,
+        so an old row's own symbol would point at a filename that was merged
+        away; asking the registry which ticker owns that ISIN or security code
+        follows the rename instead of reporting it as a missing file.
+        """
+
+        def value(name: str) -> str:
+            position = columns.get(name)
+            if position is None or position >= len(row):
+                return ""
+            return str(row[position]).strip().upper()
+
+        symbol = value("SYMBOL")
+        isin = value("ISIN")
+        security_id = value("SECURITY_ID")
+        owners = registry["exchanges"].get(exchange, {})
+        for key in (
+            f"ISIN:{isin}" if valid_isin(isin) else None,
+            f"ID:{security_id}" if valid_security_id(security_id) else None,
+        ):
+            if key is not None and key in owners:
+                symbol = owners[key]
+                break
+        if not symbol:
+            return None
+        return registry["files"].get(exchange, {}).get(
+            symbol, f"{SymbolHistoryStore.safe_filename(symbol)}.txt"
+        )
+
+    def _verify_snapshot(self, path: Path) -> Optional[bytes]:
+        """Check one raw snapshot against its own metadata and return it.
+
+        Nothing reads these digests back until a `--rebuild-*` needs the
+        snapshot, which is the worst moment to discover it is damaged: the
+        rebuild is the repair.
+        """
+
+        try:
+            payload = path.read_bytes()
+        except OSError as error:
+            self._add(
+                ERROR,
+                "unreadable-file",
+                f"the raw snapshot could not be read: {error}",
+                path=path,
+            )
+            return None
+        metadata_path = path.with_suffix(".csv.meta.json")
+        if not metadata_path.is_file():
+            self._add(
+                ERROR,
+                "raw-metadata-missing",
+                "this raw snapshot has no metadata, so no digest vouches for "
+                "it and a rebuild will refuse to read it",
+                path=path,
+            )
+            return payload
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            if not isinstance(metadata, dict):
+                raise ValueError("the metadata must be an object")
+        except (OSError, ValueError) as error:
+            self._add(
+                ERROR,
+                "raw-metadata-unreadable",
+                f"the raw snapshot metadata could not be read: {error}",
+                path=metadata_path,
+            )
+            return payload
+        digest = hashlib.sha256(payload).hexdigest()
+        if metadata.get("sha256") != digest:
+            self._add(
+                ERROR,
+                "raw-digest-mismatch",
+                "the raw snapshot does not match the sha256 its metadata "
+                "records, so a rebuild would refuse it",
+                path=path,
+            )
+            return payload
+        rows = payload.count(b"\n")
+        if payload and not payload.endswith(b"\n"):
+            rows += 1
+        rows = max(rows - 1, 0)  # the header is not a row
+        if metadata.get("row_count") != rows:
+            self._add(
+                ERROR,
+                "raw-row-count-mismatch",
+                f"the raw snapshot holds {rows} rows but its metadata records "
+                f"{metadata.get('row_count')}",
+                path=path,
+            )
+        return payload
+
+    def _expected_symbol_coverage(
+        self, exchange: str, snapshots: list[Path]
+    ) -> tuple[dict[str, int], list[date]]:
+        """Which dates each symbol file owes, as one bit per snapshot date.
+
+        A bitmask rather than a set of dates: a finished multi-year backfill
+        holds tens of millions of (symbol, date) pairs, which no audit should
+        need gigabytes to check.  One bit each keeps the whole expectation for
+        a 4,000-symbol, 7,500-session database inside a few megabytes.
+        """
+
+        index: dict[date, int] = {}
+        ordered: list[date] = []
+        for path in snapshots:
+            try:
+                snapshot_date = date.fromisoformat(path.stem)
+            except ValueError:
+                self._add(
+                    WARNING,
+                    "unrecognised-file",
+                    "this raw snapshot is not named for a date, so nothing "
+                    "can rebuild from it",
+                    path=path,
+                )
+                continue
+            if snapshot_date not in index:
+                index[snapshot_date] = len(ordered)
+                ordered.append(snapshot_date)
+
+        expected: dict[str, int] = {}
+        registry = self._registry()
+        for path in snapshots:
+            try:
+                snapshot_date = date.fromisoformat(path.stem)
+            except ValueError:
+                continue
+            payload = self._verify_snapshot(path)
+            if payload is None:
+                continue
+            bit = 1 << index[snapshot_date]
+            reader = csv.reader(payload.decode("utf-8").splitlines())
+            header = next(reader, None)
+            if header is None:
+                continue
+            # Resolved from the header rather than by position: a snapshot
+            # written by a different column order must be refused, not
+            # silently read as if SYMBOL were somewhere else.
+            columns = {name: position for position, name in enumerate(header)}
+            if "SYMBOL" not in columns:
+                self._add(
+                    ERROR,
+                    "raw-schema-unknown",
+                    "this raw snapshot has no SYMBOL column, so nothing can "
+                    "rebuild a symbol history from it",
+                    path=path,
+                )
+                continue
+            for row in reader:
+                if not row:
+                    continue
+                filename = self._snapshot_filename(
+                    exchange, registry, row, columns
+                )
+                if filename is None:
+                    continue
+                expected[filename] = expected.get(filename, 0) | bit
+        return expected, ordered
+
+    def _symbol_file_dates(
+        self, path: Path, index: dict[date, int]
+    ) -> Optional[tuple[int, list[date], bool]]:
+        """One symbol file's dates as a bitmask, its duplicates, its schema."""
+
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError) as error:
+            self._add(
+                ERROR,
+                "unreadable-file",
+                f"the symbol history could not be read: {error}",
+                path=path,
+            )
+            return None
+        if not lines:
+            self._add(
+                WARNING,
+                "empty-symbol-file",
+                "this symbol history is empty, so it carries no history at all",
+                path=path,
+            )
+            return None
+        header = lines[0].split(",")
+        current_schema = header == SYMBOL_HISTORY_COLUMNS
+        if not current_schema and header != LEGACY_SYMBOL_HISTORY_COLUMNS:
+            self._add(
+                ERROR,
+                "symbol-schema-unknown",
+                "this symbol history's header matches neither the current nor "
+                "the previous column set, so a consumer cannot read it",
+                path=path,
+            )
+            return None
+
+        mask = 0
+        seen: set[date] = set()
+        duplicates: list[date] = []
+        malformed = 0
+        for line in lines[1:]:
+            if not line:
+                continue
+            raw = line.split(",", 1)[0].strip()
+            try:
+                row_date = date(int(raw[:4]), int(raw[4:6]), int(raw[6:8]))
+            except ValueError:
+                malformed += 1
+                continue
+            if row_date in seen:
+                duplicates.append(row_date)
+            seen.add(row_date)
+            position = index.get(row_date)
+            if position is not None:
+                mask |= 1 << position
+        if malformed:
+            self._add(
+                ERROR,
+                "symbol-date-unreadable",
+                f"{malformed} row(s) carry a date this file's own format "
+                "cannot parse",
+                path=path,
+            )
+        return mask, duplicates, current_schema
+
+    def _check_symbol_histories(self, exchange: str) -> Optional[SymbolSummary]:
+        """Cross-check every ``SYMBOLS/*.txt`` against the raw snapshots.
+
+        Nothing enumerated ``<EX>/SYMBOLS/`` at all before this: a symbol file
+        could lose a year of history and only a rebuild would notice, which is
+        no use to someone asking whether a rebuild is needed.
+        """
+
+        snapshots = self._snapshot_paths(exchange)
+        folder = self.base_data_path / exchange / "SYMBOLS"
+        if not snapshots and not folder.is_dir():
+            return None
+
+        expected, ordered = self._expected_symbol_coverage(exchange, snapshots)
+        index = {value: position for position, value in enumerate(ordered)}
+        summary = SymbolSummary(
+            exchange,
+            snapshots=len(snapshots),
+            pairs=sum(mask.bit_count() for mask in expected.values()),
+        )
+
+        on_disk = {
+            path.name: path
+            for path in (sorted(folder.iterdir()) if folder.is_dir() else [])
+            if path.is_file() and path.suffix == ".txt"
+        }
+        summary.histories = len(on_disk)
+        if folder.is_dir():
+            for path in sorted(folder.iterdir()):
+                if path.is_file() and path.name.endswith(".tmp"):
+                    self._add(
+                        WARNING,
+                        "interrupted-write",
+                        "a temporary symbol file was left behind, so a write "
+                        "did not finish",
+                        exchange_segment=exchange,
+                        path=path,
+                    )
+
+        missing_files: list[str] = []
+        legacy_schema = 0
+        for filename in sorted(expected):
+            history = on_disk.get(filename)
+            if history is None:
+                missing_files.append(filename)
+                continue
+            result = self._symbol_file_dates(history, index)
+            if result is None:
+                continue
+            mask, duplicates, current_schema = result
+            if not current_schema:
+                legacy_schema += 1
+            if duplicates:
+                self._add(
+                    ERROR,
+                    "duplicate-symbol-dates",
+                    f"{len(duplicates)} date(s) appear more than once: "
+                    f"{_describe(sorted(set(duplicates)))}",
+                    exchange_segment=exchange,
+                    path=history,
+                )
+            absent = expected[filename] & ~mask
+            if absent:
+                gaps = [
+                    ordered[position]
+                    for position in range(len(ordered))
+                    if absent >> position & 1
+                ]
+                self._add(
+                    ERROR,
+                    "symbol-coverage-gap",
+                    f"{len(gaps)} date(s) present in the raw snapshots are "
+                    f"missing from this history: {_describe(gaps)}",
+                    exchange_segment=exchange,
+                    path=history,
+                )
+
+        if missing_files:
+            self._add(
+                ERROR,
+                "missing-symbol-file",
+                f"{len(missing_files)} symbol file(s) the raw snapshots "
+                f"require do not exist: {_describe(missing_files)}",
+                exchange_segment=exchange,
+            )
+
+        unaccounted = sorted(set(on_disk).difference(expected))
+        if unaccounted:
+            self._add(
+                NOTICE,
+                "unaccounted-symbol-file",
+                f"{len(unaccounted)} symbol file(s) appear in no raw snapshot, "
+                "so their history cannot be verified or rebuilt: "
+                f"{_describe(unaccounted)}",
+                exchange_segment=exchange,
+            )
+        if legacy_schema:
+            self._add(
+                NOTICE,
+                "legacy-symbol-schema",
+                f"{legacy_schema} symbol file(s) still carry the pre-ISIN "
+                "column set, so two schema generations coexist here",
+                exchange_segment=exchange,
+            )
+
+        registered = self._registry()["files"].get(exchange, {})
+        absent_registered = sorted(
+            filename for filename in set(registered.values())
+            if filename not in on_disk
+        )
+        if absent_registered:
+            self._add(
+                ERROR,
+                "missing-registered-file",
+                f"{len(absent_registered)} file(s) the registry claims to own "
+                f"do not exist: {_describe(absent_registered)}",
+                exchange_segment=exchange,
+            )
+        return summary
+
+    # ------------------------------------------------------------- state trees
+
+    def _check_state_orphans(
+        self,
+        grouped: dict[str, list[tuple[date, dict[str, Any]]]],
+        published: dict[str, dict[date, Path]],
+    ) -> None:
+        """Find working files no published date accounts for.
+
+        Both trees are written per date and read only by a repair.  One left
+        behind for a date that was never published means a run stopped in the
+        middle, and nothing else would ever say so.
+        """
+
+        state = self.base_data_path / ".state"
+        for category, kind in (
+            ("components", "reconciliation component"),
+            ("raw", "raw snapshot"),
+        ):
+            root = state / category
+            if not root.is_dir():
+                continue
+            for exchange_dir in sorted(root.iterdir()):
+                if not exchange_dir.is_dir():
+                    continue
+                for segment_dir in sorted(exchange_dir.iterdir()):
+                    if not segment_dir.is_dir():
+                        continue
+                    exchange_segment = (
+                        f"{exchange_dir.name}_{segment_dir.name}"
+                    )
+                    if exchange_segment not in self.segments:
+                        continue
+                    known = {
+                        target_date for target_date, _ in
+                        grouped.get(exchange_segment, [])
+                    }
+                    known.update(published.get(exchange_segment, {}))
+                    orphans = []
+                    for path in sorted(segment_dir.glob("*.csv")):
+                        try:
+                            snapshot_date = date.fromisoformat(path.stem)
+                        except ValueError:
+                            continue
+                        if snapshot_date not in known:
+                            orphans.append(snapshot_date)
+                    if orphans:
+                        self._add(
+                            WARNING,
+                            "orphan-working-file",
+                            f"{len(orphans)} {kind}(s) exist for dates with "
+                            "no published file and no pipeline record: "
+                            f"{_describe(orphans)}",
+                            exchange_segment=exchange_segment,
+                        )
+                    for path in sorted(segment_dir.glob("*.tmp")):
+                        self._add(
+                            WARNING,
+                            "interrupted-write",
+                            f"a temporary {kind} was left behind, so a write "
+                            "did not finish",
+                            exchange_segment=exchange_segment,
+                            path=path,
+                        )
+
+        raw_root = state / "raw"
+        if raw_root.is_dir():
+            # ``with_suffix`` cannot undo a two-part suffix: it would turn
+            # ``2026-07-01.csv.meta.json`` into ``2026-07-01.csv.csv`` and
+            # report every healthy snapshot as widowed.
+            widowed = [
+                path for path in sorted(raw_root.rglob("*.csv.meta.json"))
+                if not path.with_name(
+                    path.name[: -len(".meta.json")]
+                ).is_file()
+            ]
+            if widowed:
+                self._add(
+                    WARNING,
+                    "orphan-working-file",
+                    f"{len(widowed)} raw-snapshot metadata file(s) have no "
+                    "snapshot beside them: "
+                    f"{_describe([path.name for path in widowed])}",
+                )
+
     # ------------------------------------------------------------------- entry
 
     def run(self) -> AuditReport:
@@ -962,6 +1491,7 @@ class DatabaseAudit:
         self._relocated_reported = False
         self._unknown_calendar_years = set()
         self._measurements = {}
+        self._registry_cache = None
 
         self._note_running_instance()
         grouped = self._load_records()
@@ -980,11 +1510,13 @@ class DatabaseAudit:
             )
 
         summaries = []
+        published_by_segment: dict[str, dict[date, Path]] = {}
         for exchange_segment in self.segments:
             exchange, segment = exchange_segment.split("_", 1)
             entries = grouped.get(exchange_segment, [])
             summary = SegmentSummary(exchange_segment, records=len(entries))
             published = self._published_files(exchange, segment)
+            published_by_segment[exchange_segment] = published
             summary.files = len(published)
 
             for target_date, record in entries:
@@ -1000,6 +1532,17 @@ class DatabaseAudit:
             self._check_row_counts(exchange_segment, published, entries)
             summaries.append(summary)
 
+        symbol_summaries = [
+            summary for summary in (
+                self._check_symbol_histories(exchange)
+                for exchange in sorted(
+                    {segment.split("_", 1)[0] for segment in self.segments}
+                )
+            )
+            if summary is not None
+        ]
+        self._check_state_orphans(grouped, published_by_segment)
+
         if self._unknown_calendar_years:
             years = ", ".join(
                 str(year) for year in sorted(self._unknown_calendar_years)
@@ -1013,6 +1556,7 @@ class DatabaseAudit:
         return AuditReport(
             base_data_path=self.base_data_path,
             summaries=tuple(summaries),
+            symbols=tuple(symbol_summaries),
             findings=tuple(self._findings),
             notes=tuple(self._notes),
         )

--- a/src/services/audit_service.py
+++ b/src/services/audit_service.py
@@ -24,21 +24,24 @@ none of the ordinary routes into the data root are used here:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
 import socket
 import sqlite3
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Any, Optional, Sequence
 
 from ..core.config import Config
 from ..core.data_manager import DAILY_FILE_PATTERNS
+from ..utils import holiday_calendar
+from ..utils.date_utils import DateUtils
+from .canonical_data import BAND_SESSIONS, row_count_band_error
 from .instance_lock import SingleInstanceLock
 from .pipeline_sqlite import ReadOnlyPipelineStore
-from .state_store import file_sha256
 
 ERROR = "error"
 WARNING = "warning"
@@ -54,6 +57,115 @@ SEVERITY_ORDER = {ERROR: 0, WARNING: 1, NOTICE: 2}
 FAILING_SEVERITIES = frozenset({ERROR, WARNING})
 
 _DIGEST = re.compile(r"[0-9a-f]{64}")
+
+#: How far a session may be from its neighbours and still be judged against
+#: them.  The same bound the writer uses: a market grows over decades, so a
+#: 1995 session must not be measured against a 2026 one merely because nothing
+#: closer has been downloaded yet.
+BAND_MAX_DISTANCE_DAYS = 180
+
+#: Read size for the single pass that produces both a digest and a row count.
+_READ_BLOCK = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class FileMeasurement:
+    """What one pass over a published file establishes."""
+
+    sha256: str
+    rows: int
+
+
+def measure_file(path: Path) -> FileMeasurement:
+    """Return the digest and row count of ``path`` from a single read.
+
+    Both checks need the whole file, and an audit of a multi-year database
+    reads every published file already; reading each one twice would double
+    the only expensive part of the command.
+    """
+
+    digest = hashlib.sha256()
+    rows = 0
+    trailing_newline = True
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(_READ_BLOCK), b""):
+            digest.update(block)
+            rows += block.count(b"\n")
+            trailing_newline = block.endswith(b"\n")
+    # A final line without its newline is still a row.
+    return FileMeasurement(
+        digest.hexdigest(), rows if trailing_newline else rows + 1
+    )
+
+
+class OfflineTradingCalendar:
+    """Which days the exchanges traded, decided without a network call.
+
+    ``DataManager.is_trading_day`` asks ``HolidayManager.is_holiday``, which
+    fetches a year it does not have.  A diagnostic must not do that -- the
+    defect that withdrew v1.1.0 was a TLS failure, and an audit that hangs
+    trying to reach NSE cannot help diagnose one.
+
+    So this reads the holiday cache the application has already saved, falls
+    back to the bundled calendar, and reports a year it has neither of as
+    *unknown* rather than as holiday-free.  Guessing that a year had no
+    holidays would turn every Diwali into a missing trading day.
+    """
+
+    def __init__(self, config: Config):
+        settings = config.date_settings
+        self.weekend_skip = getattr(settings, "weekend_skip", True)
+        self.holiday_skip = getattr(settings, "holiday_skip", True)
+        cached, cached_years = config.holiday_manager.cached_calendar()
+        self._cached = cached
+        self._cached_years = set(cached_years)
+
+    def knows_year(self, year: int) -> bool:
+        return (
+            not self.holiday_skip
+            or year in self._cached_years
+            or holiday_calendar.holidays_for_year(year) is not None
+        )
+
+    def is_trading_day(self, target_date: date) -> bool:
+        if self.weekend_skip and target_date.weekday() >= 5:
+            return False
+        if not self.holiday_skip:
+            return True
+        if target_date.year in self._cached_years:
+            return target_date not in self._cached
+        bundled = holiday_calendar.holidays_for_year(target_date.year)
+        if bundled is None:
+            # Unknown rather than empty; ``knows_year`` keeps such a year out
+            # of the expected set entirely.
+            return True
+        return target_date not in bundled
+
+    def trading_days(self, first: date, last: date) -> list[date]:
+        days = []
+        current = first
+        while current <= last:
+            if self.knows_year(current.year) and self.is_trading_day(current):
+                days.append(current)
+            current += timedelta(days=1)
+        return days
+
+    def expected_last_trading_date(self) -> date:
+        """The most recent session whose reports the exchanges have published.
+
+        Mirrors ``DataManager.get_expected_last_trading_date``: today counts
+        only after the 6 p.m. IST publication time.
+        """
+
+        today = DateUtils.today_ist()
+        current = today
+        if self.is_trading_day(today) and DateUtils.is_data_available_time():
+            return today
+        if self.is_trading_day(today):
+            current = today - timedelta(days=1)
+        while not self.is_trading_day(current):
+            current -= timedelta(days=1)
+        return current
 
 
 class AuditError(RuntimeError):
@@ -187,9 +299,13 @@ class DatabaseAudit:
             ]
         else:
             self.segments = available
+        self.calendar = OfflineTradingCalendar(config)
         self._findings: list[AuditFinding] = []
         self._notes: list[str] = []
         self._relocated_reported = False
+        self._unknown_calendar_years: set[int] = set()
+        # One read per file, however many checks want to look at it.
+        self._measurements: dict[Path, Optional[FileMeasurement]] = {}
 
     # ---------------------------------------------------------------- helpers
 
@@ -213,6 +329,33 @@ class DatabaseAudit:
                 path=path,
             )
         )
+
+    def _measure(
+        self,
+        path: Path,
+        kind: str,
+        *,
+        exchange_segment: str = "",
+        target_date: Optional[date] = None,
+    ) -> Optional[FileMeasurement]:
+        """Digest and row count for one file, read once and remembered."""
+
+        if path in self._measurements:
+            return self._measurements[path]
+        try:
+            measurement: Optional[FileMeasurement] = measure_file(path)
+        except OSError as error:
+            measurement = None
+            self._add(
+                ERROR,
+                "unreadable-file",
+                f"the {kind} could not be read: {error}",
+                exchange_segment=exchange_segment,
+                target_date=target_date,
+                path=path,
+            )
+        self._measurements[path] = measurement
+        return measurement
 
     def _note_running_instance(self) -> None:
         """Say so if a download may be writing while the audit reads.
@@ -394,18 +537,15 @@ class DatabaseAudit:
                 path=Path(recorded_path),
             )
             return
-        try:
-            actual = file_sha256(path)
-        except OSError as error:
-            self._add(
-                ERROR,
-                "unreadable-file",
-                f"the {kind} could not be read: {error}",
-                exchange_segment=exchange_segment,
-                target_date=target_date,
-                path=path,
-            )
+        measurement = self._measure(
+            path,
+            kind,
+            exchange_segment=exchange_segment,
+            target_date=target_date,
+        )
+        if measurement is None:
             return
+        actual = measurement.sha256
         summary.digests_verified += 1
         if actual != recorded_digest:
             self._add(
@@ -495,19 +635,22 @@ class DatabaseAudit:
 
     # -------------------------------------------------------------- file scan
 
-    def _scan_published_folder(
-        self,
-        exchange: str,
-        segment: str,
-        recorded_dates: set[date],
-        summary: SegmentSummary,
-    ) -> None:
+    def _published_files(
+        self, exchange: str, segment: str
+    ) -> dict[date, Path]:
+        """Every file in one segment folder that matches the naming contract.
+
+        Anything else in the folder is reported here, because the folder is a
+        published interface: a leftover ``.tmp`` is an interrupted write, and
+        a stray file is something no consumer will ever read.
+        """
+
         exchange_segment = f"{exchange}_{segment}"
         folder = self.config.resolve_data_path(exchange, segment)
+        published: dict[date, Path] = {}
         if not folder.is_dir():
-            return
+            return published
         pattern = re.compile(DAILY_FILE_PATTERNS[exchange_segment])
-        earliest = min(recorded_dates) if recorded_dates else None
 
         for path in sorted(folder.iterdir()):
             if not path.is_file():
@@ -544,8 +687,17 @@ class DatabaseAudit:
                     path=path,
                 )
                 continue
+            published[file_date] = path
+        return published
 
-            summary.files += 1
+    def _report_unrecorded(
+        self,
+        exchange_segment: str,
+        published: dict[date, Path],
+        recorded_dates: set[date],
+    ) -> None:
+        earliest = min(recorded_dates) if recorded_dates else None
+        for file_date, path in sorted(published.items()):
             if file_date in recorded_dates:
                 continue
             if earliest is not None and file_date < earliest:
@@ -569,6 +721,237 @@ class DatabaseAudit:
                     path=path,
                 )
 
+    # --------------------------------------------------------------- coverage
+
+    def _configured_start(self) -> Optional[date]:
+        raw = getattr(self.config.date_settings, "base_start_date", None)
+        try:
+            return date.fromisoformat(str(raw))
+        except ValueError:
+            self._add(
+                ERROR,
+                "unusable-configuration",
+                f"base_start_date '{raw}' is not a date, so coverage cannot "
+                "be judged",
+            )
+            return None
+
+    @staticmethod
+    def _runs(expected: list[date], present: set[date]) -> list[list[date]]:
+        """Group absent dates into stretches of consecutive trading days.
+
+        One finding per stretch rather than per date: a head gap of a year is
+        one fact about the database, not two hundred and fifty of them.
+        """
+
+        runs: list[list[date]] = []
+        current: list[date] = []
+        for day in expected:
+            if day in present:
+                if current:
+                    runs.append(current)
+                    current = []
+                continue
+            current.append(day)
+        if current:
+            runs.append(current)
+        return runs
+
+    def _check_coverage(
+        self,
+        exchange_segment: str,
+        published: dict[date, Path],
+        entries: list[tuple[date, dict[str, Any]]],
+    ) -> None:
+        """Judge coverage against the configured start, not the first file.
+
+        ``get_missing_file_dates`` looks only *between* the first and last
+        filename on disk, so a truncated head and a stale tail are both
+        invisible to it.  This starts from ``base_start_date`` -- or from the
+        oldest file, when the owner has deliberately gone back further -- and
+        ends at the last session the exchanges have actually published.
+        """
+
+        if not published and not entries:
+            # A segment the owner does not download.  The audit cannot know
+            # which segments are wanted, so silence is the only honest answer.
+            return
+        configured = self._configured_start()
+        if configured is None:
+            return
+
+        floor = min([configured, *published]) if published else configured
+        ceiling = self.calendar.expected_last_trading_date()
+        if floor > ceiling:
+            return
+
+        for year in range(floor.year, ceiling.year + 1):
+            if not self.calendar.knows_year(year):
+                self._unknown_calendar_years.add(year)
+
+        expected = self.calendar.trading_days(floor, ceiling)
+        if not expected:
+            return
+
+        # A date the pipeline recorded is not a coverage question, whatever
+        # became of it: a settled absence is not a gap, a complete date is the
+        # digest check's to judge, and an unfinished one is reported below.
+        # Counting them here would report the same date twice.
+        accounted = set(published).union(
+            target_date for target_date, _record in entries
+        )
+        first_published = min(accounted) if accounted else None
+        last_published = max(accounted) if accounted else None
+
+        for run in self._runs(expected, accounted):
+            span = (
+                run[0].isoformat() if len(run) == 1
+                else f"{run[0].isoformat()} to {run[-1].isoformat()}"
+            )
+            if first_published is None:
+                self._add(
+                    WARNING,
+                    "missing-dates",
+                    f"{len(run)} expected trading day(s) ({span}) have no "
+                    "published file, and this segment has none at all",
+                    exchange_segment=exchange_segment,
+                )
+            elif run[-1] < first_published:
+                self._add(
+                    WARNING,
+                    "head-gap",
+                    f"the database starts at {first_published.isoformat()}, "
+                    f"leaving {len(run)} trading day(s) ({span}) between the "
+                    f"configured start and the oldest published file",
+                    exchange_segment=exchange_segment,
+                )
+            elif last_published is not None and run[0] > last_published:
+                # Freshness, not damage: the owner decides when to download.
+                self._add(
+                    NOTICE,
+                    "stale-tail",
+                    f"{len(run)} trading day(s) ({span}) since the newest "
+                    f"published file have not been downloaded",
+                    exchange_segment=exchange_segment,
+                )
+            else:
+                self._add(
+                    WARNING,
+                    "missing-dates",
+                    f"{len(run)} trading day(s) ({span}) inside the published "
+                    "range have no file",
+                    exchange_segment=exchange_segment,
+                )
+
+        unfinished = sorted(
+            target_date for target_date, record in entries
+            if not record.get("complete") and not record.get("skipped_reason")
+        )
+        if unfinished:
+            listed = ", ".join(day.isoformat() for day in unfinished[:5])
+            if len(unfinished) > 5:
+                listed += f", and {len(unfinished) - 5} more"
+            self._add(
+                WARNING,
+                "incomplete-date",
+                f"{len(unfinished)} date(s) never finished every required "
+                f"stage: {listed}",
+                exchange_segment=exchange_segment,
+            )
+
+    # -------------------------------------------------------------- row counts
+
+    @staticmethod
+    def _recorded_rows(record: dict[str, Any]) -> Optional[int]:
+        """The row count the writer recorded for the file it published.
+
+        The combined stage wins where it ran: for a deferred publication the
+        daily count describes the component, and the file on disk carries the
+        appended SME and Index rows as well.
+        """
+
+        stages = record.get("stages", {})
+        combined = stages.get("combined")
+        daily = stages.get("daily")
+        combined = combined if isinstance(combined, dict) else {}
+        daily = daily if isinstance(daily, dict) else {}
+        if combined.get("status") == "complete" and isinstance(
+            combined.get("rows"), int
+        ):
+            return int(combined["rows"])
+        if (
+            daily.get("status") == "complete"
+            and not daily.get("publication_deferred")
+            and isinstance(daily.get("rows"), int)
+        ):
+            return int(daily["rows"])
+        return None
+
+    def _check_row_counts(
+        self,
+        exchange_segment: str,
+        published: dict[date, Path],
+        entries: list[tuple[date, dict[str, Any]]],
+    ) -> None:
+        """Size every published file against its record and its neighbours.
+
+        The writer already bands a day against whatever sessions existed when
+        it was written, which for a backfill walking backwards is very few.
+        Judging again now, against the finished neighbourhood, is what makes a
+        truncated or placeholder day visible after the fact.  It is also the
+        only plausibility check available for files written before the
+        manifest existed, which carry no digest to compare.
+        """
+
+        recorded = {
+            target_date: rows
+            for target_date, record in entries
+            if (rows := self._recorded_rows(record)) is not None
+        }
+        on_disk: dict[date, int] = {}
+        for target_date, path in sorted(published.items()):
+            measurement = self._measure(
+                path,
+                "published file",
+                exchange_segment=exchange_segment,
+                target_date=target_date,
+            )
+            if measurement is None:
+                continue
+            on_disk[target_date] = measurement.rows
+            expected = recorded.get(target_date)
+            if expected is not None and expected != measurement.rows:
+                self._add(
+                    ERROR,
+                    "row-count-drift",
+                    f"the file holds {measurement.rows} rows but the pipeline "
+                    f"recorded {expected} when it published this date",
+                    exchange_segment=exchange_segment,
+                    target_date=target_date,
+                    path=path,
+                )
+
+        for target_date, rows in sorted(on_disk.items()):
+            neighbours = [
+                count for _distance, count in sorted(
+                    (abs((other - target_date).days), count)
+                    for other, count in on_disk.items()
+                    if other != target_date
+                    and abs((other - target_date).days)
+                    <= BAND_MAX_DISTANCE_DAYS
+                )[:BAND_SESSIONS]
+            ]
+            reason = row_count_band_error(rows, neighbours)
+            if reason is not None:
+                self._add(
+                    WARNING,
+                    "row-count-outlier",
+                    reason,
+                    exchange_segment=exchange_segment,
+                    target_date=target_date,
+                    path=published[target_date],
+                )
+
     # ------------------------------------------------------------------- entry
 
     def run(self) -> AuditReport:
@@ -577,6 +960,8 @@ class DatabaseAudit:
         self._findings = []
         self._notes = []
         self._relocated_reported = False
+        self._unknown_calendar_years = set()
+        self._measurements = {}
 
         self._note_running_instance()
         grouped = self._load_records()
@@ -599,17 +984,31 @@ class DatabaseAudit:
             exchange, segment = exchange_segment.split("_", 1)
             entries = grouped.get(exchange_segment, [])
             summary = SegmentSummary(exchange_segment, records=len(entries))
+            published = self._published_files(exchange, segment)
+            summary.files = len(published)
+
             for target_date, record in entries:
                 self._check_record_digests(
                     exchange, segment, target_date, record, summary
                 )
-            self._scan_published_folder(
-                exchange,
-                segment,
+            self._report_unrecorded(
+                exchange_segment,
+                published,
                 {target_date for target_date, _ in entries},
-                summary,
             )
+            self._check_coverage(exchange_segment, published, entries)
+            self._check_row_counts(exchange_segment, published, entries)
             summaries.append(summary)
+
+        if self._unknown_calendar_years:
+            years = ", ".join(
+                str(year) for year in sorted(self._unknown_calendar_years)
+            )
+            self._notes.append(
+                "no trading calendar is known for "
+                f"{years}, so holidays in those years cannot be told apart "
+                "from missing files; they were left out of the expected set."
+            )
 
         return AuditReport(
             base_data_path=self.base_data_path,

--- a/src/services/audit_service.py
+++ b/src/services/audit_service.py
@@ -1,0 +1,619 @@
+"""Read-only verification of a published NSE/BSE data root.
+
+The database this application builds is meant to accumulate for years and be
+traded off.  Until now "is it complete and self-consistent?" could not be
+answered without changing it: every sha256 written into the pipeline manifest
+was never read back, and the only repair tooling was the destructive
+``--rebuild-*``.
+
+This module answers that question and changes nothing.  "Changes nothing" is a
+requirement, not a courtesy -- a report produced by code that had just written
+to the database would not be evidence about the database the user has -- so
+none of the ordinary routes into the data root are used here:
+
+* ``Config.get_data_path`` creates the folder it is asked about, so
+  ``Config.resolve_data_path`` is used instead;
+* ``DataManager.__init__`` creates the whole folder structure, so the published
+  filename contract is imported from ``DAILY_FILE_PATTERNS`` directly;
+* ``PipelineManifest`` initialises its SQLite schema and imports the legacy
+  JSON in its constructor, so ``ReadOnlyPipelineStore`` is used instead;
+* ``VersionedJSONStore.read`` and ``read_internal_snapshot`` copy a file they
+  cannot parse into ``.state/quarantine``, so neither is called.  A file this
+  command cannot parse is reported, not moved.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import sqlite3
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+from ..core.config import Config
+from ..core.data_manager import DAILY_FILE_PATTERNS
+from .instance_lock import SingleInstanceLock
+from .pipeline_sqlite import ReadOnlyPipelineStore
+from .state_store import file_sha256
+
+ERROR = "error"
+WARNING = "warning"
+NOTICE = "notice"
+
+#: Worst first, so the rendered report opens with what matters.
+SEVERITY_ORDER = {ERROR: 0, WARNING: 1, NOTICE: 2}
+
+#: Findings at or above this severity make the command exit non-zero.  A
+#: notice describes something the audit cannot vouch for rather than something
+#: it found wrong -- data published before the manifest existed, for instance
+#: -- and a database full of those is not a failing database.
+FAILING_SEVERITIES = frozenset({ERROR, WARNING})
+
+_DIGEST = re.compile(r"[0-9a-f]{64}")
+
+
+class AuditError(RuntimeError):
+    """The audit could not run, as distinct from the audit finding a problem."""
+
+
+@dataclass(frozen=True)
+class AuditFinding:
+    """One thing the audit could not vouch for."""
+
+    severity: str
+    category: str
+    message: str
+    exchange_segment: str = ""
+    target_date: Optional[date] = None
+    path: Optional[Path] = None
+
+    def _location(self) -> str:
+        parts = [self.exchange_segment]
+        if self.target_date is not None:
+            parts.append(self.target_date.isoformat())
+        return " ".join(part for part in parts if part)
+
+    def render(self) -> str:
+        location = self._location()
+        head = f"{self.severity.upper():<7} {self.category}"
+        if location:
+            head = f"{head}  {location}"
+        lines = [head, f"        {self.message}"]
+        if self.path is not None:
+            lines.append(f"        {self.path}")
+        return "\n".join(lines)
+
+    @property
+    def sort_key(self) -> tuple[int, str, str, str]:
+        return (
+            SEVERITY_ORDER.get(self.severity, len(SEVERITY_ORDER)),
+            self.exchange_segment,
+            self.target_date.isoformat() if self.target_date else "",
+            self.category,
+        )
+
+
+@dataclass
+class SegmentSummary:
+    """What the audit actually looked at for one exchange segment."""
+
+    exchange_segment: str
+    records: int = 0
+    files: int = 0
+    digests_verified: int = 0
+
+    def render(self) -> str:
+        return (
+            f"  {self.exchange_segment:<10} {self.records:>6} recorded dates, "
+            f"{self.files:>6} published files, "
+            f"{self.digests_verified:>6} digests verified"
+        )
+
+
+@dataclass
+class AuditReport:
+    """Everything one ``--audit`` run established."""
+
+    base_data_path: Path
+    summaries: tuple[SegmentSummary, ...] = ()
+    findings: tuple[AuditFinding, ...] = ()
+    notes: tuple[str, ...] = ()
+
+    @property
+    def counts(self) -> dict[str, int]:
+        counts = {ERROR: 0, WARNING: 0, NOTICE: 0}
+        for finding in self.findings:
+            counts[finding.severity] = counts.get(finding.severity, 0) + 1
+        return counts
+
+    @property
+    def failed(self) -> bool:
+        return any(
+            finding.severity in FAILING_SEVERITIES for finding in self.findings
+        )
+
+    def render(self) -> str:
+        lines = [f"Audit of {self.base_data_path}", ""]
+        for note in self.notes:
+            lines.append(f"Note: {note}")
+        if self.notes:
+            lines.append("")
+        for summary in self.summaries:
+            lines.append(summary.render())
+        lines.append("")
+
+        if not self.findings:
+            lines.append("No problems found.")
+            return "\n".join(lines)
+
+        counts = self.counts
+        described = ", ".join(
+            f"{counts[severity]} {severity}{'s' if counts[severity] != 1 else ''}"
+            for severity in (ERROR, WARNING, NOTICE)
+            if counts[severity]
+        )
+        lines.append(f"{len(self.findings)} finding(s): {described}.")
+        lines.append("")
+        for finding in sorted(self.findings, key=lambda item: item.sort_key):
+            lines.append(finding.render())
+        return "\n".join(lines)
+
+
+class DatabaseAudit:
+    """Verify a data root against its own pipeline records, writing nothing."""
+
+    def __init__(
+        self, config: Config, segments: Optional[Sequence[str]] = None
+    ):
+        self.config = config
+        self.base_data_path = Path(config.base_data_path)
+        available = list(config.get_available_exchanges())
+        if segments:
+            requested = [str(segment).upper() for segment in segments]
+            unknown = sorted(
+                set(requested).difference(available)
+            )
+            if unknown:
+                raise AuditError(
+                    f"unknown exchange segment(s): {', '.join(unknown)}. "
+                    f"Known segments: {', '.join(available)}"
+                )
+            self.segments = [
+                segment for segment in available if segment in set(requested)
+            ]
+        else:
+            self.segments = available
+        self._findings: list[AuditFinding] = []
+        self._notes: list[str] = []
+        self._relocated_reported = False
+
+    # ---------------------------------------------------------------- helpers
+
+    def _add(
+        self,
+        severity: str,
+        category: str,
+        message: str,
+        *,
+        exchange_segment: str = "",
+        target_date: Optional[date] = None,
+        path: Optional[Path] = None,
+    ) -> None:
+        self._findings.append(
+            AuditFinding(
+                severity=severity,
+                category=category,
+                message=message,
+                exchange_segment=exchange_segment,
+                target_date=target_date,
+                path=path,
+            )
+        )
+
+    def _note_running_instance(self) -> None:
+        """Say so if a download may be writing while the audit reads.
+
+        The lock is deliberately not acquired: this command is read-only, and
+        taking the writer's lock would stop a running GUI to answer a question
+        about it.
+        """
+
+        holder = SingleInstanceLock(self.base_data_path).holder()
+        if not holder:
+            return
+        pid = holder.get("pid")
+        if (
+            os.name == "posix"
+            and isinstance(pid, int)
+            and holder.get("host") == socket.gethostname()
+        ):
+            # Only on POSIX.  On Windows ``os.kill`` with signal 0 does not
+            # probe the process, it calls TerminateProcess -- a read-only
+            # command must never take that path.
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return
+            except OSError:
+                pass  # Alive, owned by another user.
+        self._notes.append(
+            f"another copy of the application holds the data-root lock "
+            f"(pid {pid}); anything it is writing now may read as a problem."
+        )
+
+    # ----------------------------------------------------------- record loading
+
+    def _load_records(self) -> dict[str, list[tuple[date, dict[str, Any]]]]:
+        """Group valid pipeline records by exchange segment, oldest first."""
+
+        store = ReadOnlyPipelineStore(
+            self.base_data_path / ".state" / "pipeline_state.sqlite3"
+        )
+        if not store.exists():
+            self._notes.append(
+                "there is no pipeline database in this data root, so no "
+                "digest recorded at download time could be checked."
+            )
+            return {}
+        try:
+            rows = store.raw_records()
+        except sqlite3.DatabaseError as error:
+            raise AuditError(
+                f"the pipeline database could not be read: {error}"
+            ) from error
+
+        grouped: dict[str, list[tuple[date, dict[str, Any]]]] = {}
+        for key, payload in rows:
+            record = self._parse_record(key, payload)
+            if record is None:
+                continue
+            exchange_segment = f"{record['exchange']}_{record['segment']}"
+            target_date = date.fromisoformat(record["date"])
+            grouped.setdefault(exchange_segment, []).append(
+                (target_date, record)
+            )
+        for entries in grouped.values():
+            entries.sort(key=lambda entry: entry[0])
+        return grouped
+
+    def _parse_record(self, key: str, payload: str) -> Optional[dict[str, Any]]:
+        """Return one record, or report why it cannot be used and return None."""
+
+        try:
+            record = json.loads(payload)
+        except ValueError as error:
+            self._add(
+                ERROR,
+                "unreadable-record",
+                f"pipeline record '{key}' is not valid JSON: {error}",
+            )
+            return None
+        if not isinstance(record, dict):
+            self._add(
+                ERROR,
+                "unreadable-record",
+                f"pipeline record '{key}' is not an object",
+            )
+            return None
+        exchange = record.get("exchange")
+        segment = record.get("segment")
+        raw_date = record.get("date")
+        stages = record.get("stages")
+        if (
+            not isinstance(exchange, str)
+            or not isinstance(segment, str)
+            or not isinstance(raw_date, str)
+            or not isinstance(stages, dict)
+        ):
+            self._add(
+                ERROR,
+                "unreadable-record",
+                f"pipeline record '{key}' does not identify one date's stages",
+            )
+            return None
+        try:
+            date.fromisoformat(raw_date)
+        except ValueError:
+            self._add(
+                ERROR,
+                "unreadable-record",
+                f"pipeline record '{key}' has an invalid date '{raw_date}'",
+            )
+            return None
+        return record
+
+    # ------------------------------------------------------------- digest check
+
+    def _resolve(self, recorded: str, fallback: Path) -> Optional[Path]:
+        """Find a recorded file, allowing for a data root that has moved.
+
+        Recorded paths are absolute and were written on the machine that
+        produced them, so a restored backup or a copied data root would
+        otherwise report every single file as missing.
+        """
+
+        path = Path(recorded)
+        if path.is_file():
+            return path
+        if fallback.is_file():
+            if not self._relocated_reported:
+                self._relocated_reported = True
+                self._notes.append(
+                    f"recorded paths point outside {self.base_data_path}, so "
+                    "files were matched by their place in this data root "
+                    "instead; the database was written under a different path."
+                )
+            return fallback
+        return None
+
+    def _verify_digest(
+        self,
+        recorded_path: Any,
+        recorded_digest: Any,
+        fallback: Path,
+        kind: str,
+        *,
+        exchange_segment: str,
+        target_date: date,
+        summary: SegmentSummary,
+    ) -> None:
+        if not isinstance(recorded_path, str) or not recorded_path:
+            self._add(
+                ERROR,
+                "incomplete-record",
+                f"the {kind} is recorded complete but with no path",
+                exchange_segment=exchange_segment,
+                target_date=target_date,
+            )
+            return
+        if not isinstance(recorded_digest, str) or not _DIGEST.fullmatch(
+            recorded_digest
+        ):
+            self._add(
+                ERROR,
+                "incomplete-record",
+                f"the {kind} is recorded complete but with no usable sha256",
+                exchange_segment=exchange_segment,
+                target_date=target_date,
+                path=Path(recorded_path),
+            )
+            return
+
+        path = self._resolve(recorded_path, fallback)
+        if path is None:
+            self._add(
+                ERROR,
+                "missing-file",
+                f"the {kind} recorded for this date is not on disk",
+                exchange_segment=exchange_segment,
+                target_date=target_date,
+                path=Path(recorded_path),
+            )
+            return
+        try:
+            actual = file_sha256(path)
+        except OSError as error:
+            self._add(
+                ERROR,
+                "unreadable-file",
+                f"the {kind} could not be read: {error}",
+                exchange_segment=exchange_segment,
+                target_date=target_date,
+                path=path,
+            )
+            return
+        summary.digests_verified += 1
+        if actual != recorded_digest:
+            self._add(
+                ERROR,
+                "digest-mismatch",
+                f"the {kind} does not match the sha256 recorded when it was "
+                f"written (recorded {recorded_digest[:12]}, "
+                f"found {actual[:12]})",
+                exchange_segment=exchange_segment,
+                target_date=target_date,
+                path=path,
+            )
+
+    def _check_record_digests(
+        self,
+        exchange: str,
+        segment: str,
+        target_date: date,
+        record: dict[str, Any],
+        summary: SegmentSummary,
+    ) -> None:
+        exchange_segment = f"{exchange}_{segment}"
+        stages = record.get("stages", {})
+        daily = stages.get("daily")
+        combined = stages.get("combined")
+        daily = daily if isinstance(daily, dict) else {}
+        combined = combined if isinstance(combined, dict) else {}
+
+        if daily.get("status") == "complete":
+            component_path = daily.get("component_path")
+            component_digest = daily.get("component_sha256")
+            if component_path or component_digest:
+                self._verify_digest(
+                    component_path,
+                    component_digest,
+                    self.base_data_path / ".state" / "components" / exchange
+                    / segment / f"{target_date.isoformat()}.csv",
+                    "reconciliation component",
+                    exchange_segment=exchange_segment,
+                    target_date=target_date,
+                    summary=summary,
+                )
+
+            published_fallback = (
+                self.config.resolve_data_path(exchange, segment)
+                / f"{target_date.isoformat()}-{exchange}-{segment}.txt"
+            )
+            if daily.get("publication_deferred"):
+                # For a deferred publication the daily ``sha256`` describes the
+                # component, not the file at ``path``: the published EQ file is
+                # written later by the combined stage, after SME and Index rows
+                # have been appended, and that stage records its own digest.
+                # Comparing here would report every combined date as corrupt.
+                if combined.get("status") != "complete":
+                    self._add(
+                        WARNING,
+                        "unpublished-date",
+                        "this date was prepared but its combined publication "
+                        "did not complete, so no digest vouches for the "
+                        "published file",
+                        exchange_segment=exchange_segment,
+                        target_date=target_date,
+                        path=published_fallback,
+                    )
+            else:
+                self._verify_digest(
+                    daily.get("path"),
+                    daily.get("sha256"),
+                    published_fallback,
+                    "published file",
+                    exchange_segment=exchange_segment,
+                    target_date=target_date,
+                    summary=summary,
+                )
+
+        if combined.get("status") == "complete":
+            self._verify_digest(
+                combined.get("path"),
+                combined.get("sha256"),
+                self.config.resolve_data_path(exchange, "EQ")
+                / f"{target_date.isoformat()}-{exchange}-EQ.txt",
+                "combined file",
+                exchange_segment=exchange_segment,
+                target_date=target_date,
+                summary=summary,
+            )
+
+    # -------------------------------------------------------------- file scan
+
+    def _scan_published_folder(
+        self,
+        exchange: str,
+        segment: str,
+        recorded_dates: set[date],
+        summary: SegmentSummary,
+    ) -> None:
+        exchange_segment = f"{exchange}_{segment}"
+        folder = self.config.resolve_data_path(exchange, segment)
+        if not folder.is_dir():
+            return
+        pattern = re.compile(DAILY_FILE_PATTERNS[exchange_segment])
+        earliest = min(recorded_dates) if recorded_dates else None
+
+        for path in sorted(folder.iterdir()):
+            if not path.is_file():
+                continue
+            match = pattern.fullmatch(path.name)
+            if match is None:
+                if path.name.endswith(".tmp"):
+                    self._add(
+                        WARNING,
+                        "interrupted-write",
+                        "a temporary file was left behind, so a write did not "
+                        "finish",
+                        exchange_segment=exchange_segment,
+                        path=path,
+                    )
+                else:
+                    self._add(
+                        NOTICE,
+                        "unrecognised-file",
+                        "this file does not match the published naming "
+                        "contract, so nothing reads it",
+                        exchange_segment=exchange_segment,
+                        path=path,
+                    )
+                continue
+            try:
+                file_date = date.fromisoformat(match.group(1))
+            except ValueError:
+                self._add(
+                    WARNING,
+                    "unrecognised-file",
+                    "this filename carries a date that does not exist",
+                    exchange_segment=exchange_segment,
+                    path=path,
+                )
+                continue
+
+            summary.files += 1
+            if file_date in recorded_dates:
+                continue
+            if earliest is not None and file_date < earliest:
+                self._add(
+                    NOTICE,
+                    "unrecorded-file",
+                    "this file predates every pipeline record in this data "
+                    "root, so no digest can vouch for it",
+                    exchange_segment=exchange_segment,
+                    target_date=file_date,
+                    path=path,
+                )
+            else:
+                self._add(
+                    WARNING,
+                    "unrecorded-file",
+                    "this file is not recorded in the pipeline database, so "
+                    "nothing states where it came from",
+                    exchange_segment=exchange_segment,
+                    target_date=file_date,
+                    path=path,
+                )
+
+    # ------------------------------------------------------------------- entry
+
+    def run(self) -> AuditReport:
+        """Verify the selected segments and return what was found."""
+
+        self._findings = []
+        self._notes = []
+        self._relocated_reported = False
+
+        self._note_running_instance()
+        grouped = self._load_records()
+
+        for exchange_segment in sorted(grouped):
+            if exchange_segment in self.segments:
+                continue
+            if exchange_segment in self.config.get_available_exchanges():
+                continue
+            self._add(
+                NOTICE,
+                "unknown-segment",
+                f"the pipeline database holds {len(grouped[exchange_segment])} "
+                f"record(s) for '{exchange_segment}', which this version does "
+                "not publish",
+            )
+
+        summaries = []
+        for exchange_segment in self.segments:
+            exchange, segment = exchange_segment.split("_", 1)
+            entries = grouped.get(exchange_segment, [])
+            summary = SegmentSummary(exchange_segment, records=len(entries))
+            for target_date, record in entries:
+                self._check_record_digests(
+                    exchange, segment, target_date, record, summary
+                )
+            self._scan_published_folder(
+                exchange,
+                segment,
+                {target_date for target_date, _ in entries},
+                summary,
+            )
+            summaries.append(summary)
+
+        return AuditReport(
+            base_data_path=self.base_data_path,
+            summaries=tuple(summaries),
+            findings=tuple(self._findings),
+            notes=tuple(self._notes),
+        )

--- a/src/services/audit_service.py
+++ b/src/services/audit_service.py
@@ -76,6 +76,14 @@ BAND_MAX_DISTANCE_DAYS = 180
 #: Read size for the single pass that produces both a digest and a row count.
 _READ_BLOCK = 1024 * 1024
 
+#: The longest run of closed days the calendar walk will step back over.  The
+#: exchanges have never closed for anything near this long.
+_MAX_CLOSED_RUN = 60
+
+#: Segments whose rows become symbol histories, and therefore the ones whose
+#: selection makes the ``SYMBOLS`` cross-check relevant.
+SYMBOL_BEARING_SEGMENTS = frozenset({"EQ", "SME"})
+
 #: How many individual dates or filenames one aggregated finding names before
 #: it falls back to a count.  A finding nobody can read is not a finding.
 _LISTED = 5
@@ -186,7 +194,11 @@ class OfflineTradingCalendar:
             return today
         if self.is_trading_day(today):
             current = today - timedelta(days=1)
-        while not self.is_trading_day(current):
+        # Bounded: a holiday cache that somehow marked every day a holiday
+        # would otherwise walk backwards for ever inside a diagnostic.
+        for _ in range(_MAX_CLOSED_RUN):
+            if self.is_trading_day(current):
+                return current
             current -= timedelta(days=1)
         return current
 
@@ -731,6 +743,17 @@ class DatabaseAudit:
                     path=path,
                 )
                 continue
+            if file_date in published:
+                self._add(
+                    WARNING,
+                    "duplicate-published-file",
+                    "two files claim this date, and which one a consumer "
+                    f"reads depends on the directory order: {path.name} and "
+                    f"{published[file_date].name}",
+                    exchange_segment=exchange_segment,
+                    target_date=file_date,
+                    path=path,
+                )
             published[file_date] = path
         return published
 
@@ -1184,7 +1207,17 @@ class DatabaseAudit:
             if payload is None:
                 continue
             bit = 1 << index[snapshot_date]
-            reader = csv.reader(payload.decode("utf-8").splitlines())
+            try:
+                decoded = payload.decode("utf-8")
+            except UnicodeDecodeError as error:
+                self._add(
+                    ERROR,
+                    "raw-schema-unknown",
+                    f"this raw snapshot is not readable as text: {error}",
+                    path=path,
+                )
+                continue
+            reader = csv.reader(decoded.splitlines())
             header = next(reader, None)
             if header is None:
                 continue
@@ -1532,12 +1565,21 @@ class DatabaseAudit:
             self._check_row_counts(exchange_segment, published, entries)
             summaries.append(summary)
 
+        # Every raw snapshot for the exchange is used, whichever of its
+        # segments was asked for -- EQ and SME write into one ``SYMBOLS``
+        # folder, so judging it from half the snapshots would report the other
+        # half's securities as unaccounted for.  Only the *trigger* narrows:
+        # someone auditing NSE_FO did not ask about symbol histories.
+        symbol_exchanges = sorted({
+            exchange for exchange, segment in (
+                value.split("_", 1) for value in self.segments
+            )
+            if segment in SYMBOL_BEARING_SEGMENTS
+        })
         symbol_summaries = [
             summary for summary in (
                 self._check_symbol_histories(exchange)
-                for exchange in sorted(
-                    {segment.split("_", 1)[0] for segment in self.segments}
-                )
+                for exchange in symbol_exchanges
             )
             if summary is not None
         ]

--- a/src/services/instance_lock.py
+++ b/src/services/instance_lock.py
@@ -120,8 +120,14 @@ class SingleInstanceLock:
         self.path = self.base_path / ".state" / "app.lock"
         self._state: Optional[_LockState] = None
 
-    def _holder(self) -> Optional[dict[str, Any]]:
-        """Read whatever the holding process wrote about itself."""
+    def holder(self) -> Optional[dict[str, Any]]:
+        """Read whatever the holding process wrote about itself.
+
+        Public because ``--audit`` needs to say "a download may be running"
+        without acquiring the lock: taking it would stop the GUI, and a
+        read-only command has no business holding a writer's lock.  ``release``
+        truncates the file, so an empty file means nobody is holding it.
+        """
 
         try:
             content = self.path.read_text(encoding="utf-8").strip()
@@ -141,7 +147,7 @@ class SingleInstanceLock:
             locked = _lock_handle(handle)
         except OSError:
             handle.close()
-            raise InstanceLockError(self.path, self._holder()) from None
+            raise InstanceLockError(self.path, self.holder()) from None
         except Exception:
             handle.close()
             raise

--- a/src/services/pipeline_sqlite.py
+++ b/src/services/pipeline_sqlite.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sqlite3
+import tempfile
 from contextlib import contextmanager
 from datetime import date
 from pathlib import Path
@@ -370,3 +372,72 @@ class SQLitePipelineStore:
             return [date.fromisoformat(row["target_date"]) for row in rows]
         except (sqlite3.DatabaseError, ValueError) as error:
             self._raise_corruption(error)
+
+
+class ReadOnlyPipelineStore:
+    """Read pipeline records without touching the database or its directory.
+
+    Every other route into this database writes before it reads.
+    ``SQLitePipelineStore.__init__`` sets the journal mode, creates the tables
+    and inserts the schema version; ``PipelineManifest.__init__`` additionally
+    imports the legacy JSON and copies it aside; and a record that fails to
+    parse is quarantined, which is another write.  ``--audit`` must do none of
+    that: a report is only evidence about a database if producing it did not
+    change that database.
+
+    SQLite's own ``mode=ro`` is not sufficient, which was found by measuring
+    rather than by reading the documentation.  Opening the real data root that
+    way left ``pipeline_state.sqlite3-shm`` rewritten: a WAL database needs its
+    shared-memory index, and a read-only *connection* still creates and stamps
+    that file.  On a genuinely read-only medium it would fail outright.
+
+    So the database is copied to a temporary directory outside the data root
+    and the copy is opened.  The ``-wal`` file is copied after it, in that
+    order, because in WAL mode the main file only changes during a checkpoint;
+    the ``-shm`` file is deliberately *not* copied, since SQLite rebuilds it
+    from the WAL and a stale one is worse than none.  A copy torn by a
+    concurrent writer surfaces as a database error, which the caller reports
+    as "the audit could not look" rather than as a finding about the data.
+
+    Rows are returned exactly as stored.  Deciding what a malformed row means
+    is the caller's job, because for the audit a malformed row is a finding to
+    report rather than an error to raise.
+    """
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+
+    def exists(self) -> bool:
+        return self.path.is_file()
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        with tempfile.TemporaryDirectory(prefix="nse-bse-audit-") as scratch:
+            copy = Path(scratch) / self.path.name
+            shutil.copy2(self.path, copy)
+            write_ahead_log = Path(f"{self.path}-wal")
+            if write_ahead_log.is_file():
+                shutil.copy2(write_ahead_log, Path(f"{copy}-wal"))
+            connection = sqlite3.connect(copy, timeout=30)
+            connection.row_factory = sqlite3.Row
+            try:
+                connection.execute("PRAGMA query_only=ON")
+                yield connection
+            finally:
+                connection.close()
+
+    def raw_records(self) -> list[tuple[str, str]]:
+        """Return ``(record_key, record_json)`` pairs, oldest date first.
+
+        Raises ``sqlite3.DatabaseError`` if the file cannot be read at all;
+        that is a failure of the audit, not a finding about the data.
+        """
+
+        if not self.exists():
+            return []
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT record_key, record_json FROM pipeline_dates "
+                "ORDER BY target_date, record_key"
+            ).fetchall()
+        return [(row["record_key"], row["record_json"]) for row in rows]

--- a/src/utils/holiday_manager.py
+++ b/src/utils/holiday_manager.py
@@ -212,6 +212,24 @@ class HolidayManager:
             )
         return holidays, updated_at, years
 
+    def cached_calendar(self) -> Tuple[Set[date], Set[int]]:
+        """Holidays already on disk, and the years they actually cover.
+
+        ``get_holidays`` reaches the network when a year is missing or stale,
+        which a read-only diagnostic such as ``--audit`` must not do: an audit
+        that hangs on a broken TLS stack is no use for diagnosing one.  This
+        reports only what is already known, and says which years that is, so a
+        caller can decline to judge a year whose calendar it does not have
+        rather than mistake every holiday in it for a missing trading day.
+        """
+
+        try:
+            holidays, _updated_at, years = self._load_cache_record()
+        except Exception as error:
+            self.logger.error("Failed to load holiday cache: %s", error)
+            return set(), set()
+        return holidays, years
+
     def load_holidays_from_cache(self) -> Set[date]:
         try:
             holidays, _, _ = self._load_cache_record()

--- a/tests/test_audit_command.py
+++ b/tests/test_audit_command.py
@@ -10,6 +10,7 @@ caught SQLite's own `mode=ro` rewriting `pipeline_state.sqlite3-shm`.
 from __future__ import annotations
 
 import hashlib
+import json
 from datetime import date
 from pathlib import Path
 
@@ -18,6 +19,11 @@ import pytest
 import main
 from src.core.config import Config
 from src.services.audit_service import AuditError, DatabaseAudit
+from src.services.canonical_data import (
+    INTERNAL_EQUITY_COLUMNS,
+    LEGACY_SYMBOL_HISTORY_COLUMNS,
+    SYMBOL_HISTORY_COLUMNS,
+)
 from src.services.pipeline_state import PipelineManifest
 
 DAY = date(2026, 7, 30)
@@ -112,7 +118,7 @@ def _record_simple(base: Path, segment: str, target_date: date, path: Path):
         "complete",
         path=str(path),
         sha256=_digest(path),
-        rows=1,
+        rows=len(path.read_text(encoding="utf-8").splitlines()),
     )
     return manifest
 
@@ -720,3 +726,258 @@ def test_a_file_that_gained_rows_since_publication_says_how(healthy):
     }
     drift = _categories(report, "row-count-drift")[0]
     assert "holds 2 rows but the pipeline recorded 1" in drift.message
+
+
+# --------------------------------------------------------------------------
+# Symbol histories, raw snapshots and orphans
+# --------------------------------------------------------------------------
+
+ACME = ("ACME", "INE000A01001", "1")
+BOLT = ("BOLT", "INE000B01002", "2")
+
+
+def _write_snapshot(config, exchange, segment, day, securities) -> Path:
+    """One checksummed raw snapshot, written the way the store writes it."""
+
+    folder = config.base_data_path / ".state" / "raw" / exchange / segment
+    folder.mkdir(parents=True, exist_ok=True)
+    lines = [",".join(INTERNAL_EQUITY_COLUMNS)]
+    for symbol, isin, security_id in securities:
+        values = {
+            "SYMBOL": symbol,
+            "DATE": day.strftime("%Y%m%d"),
+            "ISIN": isin,
+            "SECURITY_ID": security_id,
+            "SERIES": "EQ",
+        }
+        lines.append(
+            ",".join(values.get(column, "1") for column in
+                     INTERNAL_EQUITY_COLUMNS)
+        )
+    body = "\n".join(lines) + "\n"
+    path = folder / f"{day.isoformat()}.csv"
+    path.write_text(body, encoding="utf-8")
+    path.with_suffix(".csv.meta.json").write_text(
+        json.dumps({
+            "version": 1,
+            "exchange": exchange,
+            "segment": segment,
+            "target_date": day.isoformat(),
+            "row_count": len(securities),
+            "sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        }),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_history(config, exchange, filename, days, *, legacy=False) -> Path:
+    columns = (
+        LEGACY_SYMBOL_HISTORY_COLUMNS if legacy else SYMBOL_HISTORY_COLUMNS
+    )
+    folder = config.base_data_path / exchange / "SYMBOLS"
+    folder.mkdir(parents=True, exist_ok=True)
+    lines = [",".join(columns)]
+    for day in days:
+        lines.append(
+            ",".join([day.strftime("%Y%m%d")] + ["1"] * (len(columns) - 1))
+        )
+    path = folder / filename
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def symbols_root(tmp_path):
+    """Two NSE EQ sessions, published, recorded, snapshotted and historied."""
+
+    config = _config(EARLIER)
+    for day in (EARLIER, DAY):
+        published = _publish(config, "EQ", day, "ACME,1\nBOLT,1\n")
+        _record_simple(config.base_data_path, "EQ", day, published)
+        _write_snapshot(config, "NSE", "EQ", day, [ACME, BOLT])
+    _write_history(config, "NSE", "acme.txt", [EARLIER, DAY])
+    _write_history(config, "NSE", "bolt.txt", [EARLIER, DAY])
+    return config
+
+
+def test_a_consistent_symbol_tree_reports_nothing(symbols_root):
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    assert report.findings == ()
+
+
+def test_a_symbol_history_missing_a_snapshot_date_is_caught(symbols_root):
+    # Nothing enumerated `<EX>/SYMBOLS/` before this, so a history could lose
+    # a session and only a rebuild would ever notice.
+    _write_history(symbols_root, "NSE", "bolt.txt", [EARLIER])
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    gaps = _categories(report, "symbol-coverage-gap")
+    assert len(gaps) == 1
+    assert gaps[0].path.name == "bolt.txt"
+    assert DAY.isoformat() in gaps[0].message
+    assert report.failed
+
+
+def test_a_symbol_file_the_snapshots_require_is_reported_when_absent(
+    symbols_root,
+):
+    (symbols_root.base_data_path / "NSE" / "SYMBOLS" / "bolt.txt").unlink()
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    missing = _categories(report, "missing-symbol-file")
+    assert len(missing) == 1
+    assert "bolt.txt" in missing[0].message
+
+
+def test_a_renamed_security_is_followed_by_identity_not_by_ticker(
+    symbols_root,
+):
+    """A rename merges the history into the new name's file.
+
+    Resolving an old snapshot row by its own ticker would look for a file the
+    merge deleted, and report a healthy database as missing thousands of them.
+    """
+
+    history = symbols_root.base_data_path / "NSE" / "SYMBOLS"
+    (history / "acme.txt").rename(history / "acmecorp.txt")
+    registry = symbols_root.base_data_path / ".state" / "symbol_registry.json"
+    registry.write_text(
+        json.dumps({
+            "version": 3,
+            "exchanges": {"NSE": {"ISIN:INE000A01001": "ACMECORP"}},
+            "files": {"NSE": {"ACMECORP": "acmecorp.txt"}},
+            "identities": {},
+        }),
+        encoding="utf-8",
+    )
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    assert report.findings == ()
+
+
+def test_a_damaged_raw_snapshot_is_caught_by_its_own_metadata(symbols_root):
+    # These digests are written and then never read until a `--rebuild-*`
+    # needs them, which is the worst moment to find the snapshot damaged.
+    snapshot = (
+        symbols_root.base_data_path / ".state" / "raw" / "NSE" / "EQ"
+        / f"{DAY.isoformat()}.csv"
+    )
+    snapshot.write_text(
+        snapshot.read_text(encoding="utf-8").replace("BOLT", "BOLTX"),
+        encoding="utf-8",
+    )
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    assert [
+        finding.category for finding in _categories(
+            report, "raw-digest-mismatch"
+        )
+    ] == ["raw-digest-mismatch"]
+    assert report.failed
+
+
+def test_a_raw_snapshot_without_metadata_cannot_be_rebuilt_from(symbols_root):
+    (
+        symbols_root.base_data_path / ".state" / "raw" / "NSE" / "EQ"
+        / f"{DAY.isoformat()}.csv.meta.json"
+    ).unlink()
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    assert len(_categories(report, "raw-metadata-missing")) == 1
+
+
+def test_metadata_left_without_its_snapshot_is_reported(symbols_root):
+    (
+        symbols_root.base_data_path / ".state" / "raw" / "NSE" / "EQ"
+        / f"{DAY.isoformat()}.csv"
+    ).unlink()
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    orphans = _categories(report, "orphan-working-file")
+    assert any("metadata" in finding.message for finding in orphans)
+
+
+def test_repeated_dates_in_a_symbol_history_are_reported(symbols_root):
+    _write_history(symbols_root, "NSE", "acme.txt", [EARLIER, DAY, DAY])
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    duplicates = _categories(report, "duplicate-symbol-dates")
+    assert len(duplicates) == 1
+    assert DAY.isoformat() in duplicates[0].message
+
+
+def test_a_symbol_history_with_an_unknown_header_is_refused(symbols_root):
+    path = symbols_root.base_data_path / "NSE" / "SYMBOLS" / "acme.txt"
+    path.write_text("WHO,KNOWS\n20260730,1\n", encoding="utf-8")
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    assert len(_categories(report, "symbol-schema-unknown")) == 1
+
+
+def test_the_older_symbol_schema_is_noted_rather_than_failed(symbols_root):
+    _write_history(
+        symbols_root, "NSE", "acme.txt", [EARLIER, DAY], legacy=True
+    )
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    legacy = _categories(report, "legacy-symbol-schema")
+    assert len(legacy) == 1
+    assert legacy[0].severity == "notice"
+    assert not report.failed
+
+
+def test_a_symbol_file_no_snapshot_covers_is_a_notice(symbols_root):
+    _write_history(symbols_root, "NSE", "ghost.txt", [EARLIER])
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    unaccounted = _categories(report, "unaccounted-symbol-file")
+    assert len(unaccounted) == 1
+    assert "ghost.txt" in unaccounted[0].message
+    assert not report.failed
+
+
+def test_a_working_file_for_an_unpublished_date_is_an_orphan(symbols_root):
+    stray = date(2026, 7, 28)
+    _write_snapshot(symbols_root, "NSE", "EQ", stray, [ACME])
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    orphans = [
+        finding for finding in _categories(report, "orphan-working-file")
+        if "raw snapshot" in finding.message
+    ]
+    assert len(orphans) == 1
+    assert stray.isoformat() in orphans[0].message
+
+
+def test_a_registry_naming_a_file_that_does_not_exist_is_reported(
+    symbols_root,
+):
+    registry = symbols_root.base_data_path / ".state" / "symbol_registry.json"
+    registry.write_text(
+        json.dumps({
+            "version": 3,
+            "exchanges": {},
+            "files": {"NSE": {"GONE": "gone.txt"}},
+            "identities": {},
+        }),
+        encoding="utf-8",
+    )
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    missing = _categories(report, "missing-registered-file")
+    assert len(missing) == 1
+    assert "gone.txt" in missing[0].message

--- a/tests/test_audit_command.py
+++ b/tests/test_audit_command.py
@@ -24,6 +24,49 @@ DAY = date(2026, 7, 30)
 EARLIER = date(2026, 7, 29)
 
 
+def _pin_clock(monkeypatch, day: date) -> None:
+    monkeypatch.setattr(
+        "src.utils.date_utils.DateUtils.today_ist", classmethod(lambda cls: day)
+    )
+    monkeypatch.setattr(
+        "src.utils.date_utils.DateUtils.is_data_available_time",
+        staticmethod(lambda now=None: True),
+    )
+
+
+@pytest.fixture(autouse=True)
+def fixed_clock(monkeypatch):
+    """Pin "the last session the exchanges published" to the fixture date.
+
+    Coverage is judged up to the newest session that exists, so without this
+    every test would grow a stale-tail finding as the real calendar moved on.
+    """
+
+    _pin_clock(monkeypatch, DAY)
+
+
+def _config(start: date = DAY) -> Config:
+    """A configuration whose data root is this test's temporary home."""
+
+    config = Config("config.yaml")
+    config.date_settings.base_start_date = start.isoformat()
+    return config
+
+
+def _config_file(tmp_path: Path, start: date = DAY) -> str:
+    """The shipped configuration, re-pointed at this test's start date."""
+
+    shipped = Path("config.yaml").read_text(encoding="utf-8")
+    target = tmp_path / "audit-config.yaml"
+    target.write_text(
+        shipped.replace(
+            'base_start_date: "2025-07-15"', f'base_start_date: "{start}"'
+        ),
+        encoding="utf-8",
+    )
+    return str(target)
+
+
 def _digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -78,7 +121,7 @@ def _record_simple(base: Path, segment: str, target_date: date, path: Path):
 def healthy(tmp_path):
     """A data root holding one recorded, verifiable NSE_FO date."""
 
-    config = Config("config.yaml")
+    config = _config()
     published = _publish(config, "FO", DAY, "SYMBOL,1,2,3\n")
     _record_simple(config.base_data_path, "FO", DAY, published)
     return config, published
@@ -219,7 +262,7 @@ def deferred(tmp_path):
     which is the false positive this fixture exists to pin down.
     """
 
-    config = Config("config.yaml")
+    config = _config()
     component_dir = config.base_data_path / ".state" / "components" / "NSE" / "EQ"
     component_dir.mkdir(parents=True)
     component = component_dir / f"{DAY.isoformat()}.csv"
@@ -262,14 +305,15 @@ def test_a_date_that_never_reached_publication_is_reported(deferred):
 
     report = DatabaseAudit(config, ["NSE_EQ"]).run()
 
-    assert [finding.category for finding in report.findings] == [
-        "unpublished-date"
-    ]
+    assert {finding.category for finding in report.findings} == {
+        "unpublished-date",
+        "incomplete-date",
+    }
     assert report.failed
 
 
 def test_an_unknown_segment_is_refused_before_anything_is_read(tmp_path):
-    config = Config("config.yaml")
+    config = _config()
 
     with pytest.raises(AuditError) as error:
         DatabaseAudit(config, ["NSE_COMMODITY"])
@@ -278,7 +322,7 @@ def test_an_unknown_segment_is_refused_before_anything_is_read(tmp_path):
 
 
 def test_a_root_with_no_pipeline_database_says_so(tmp_path):
-    config = Config("config.yaml")
+    config = _config()
 
     report = DatabaseAudit(config, ["NSE_FO"]).run()
 
@@ -286,28 +330,31 @@ def test_a_root_with_no_pipeline_database_says_so(tmp_path):
     assert any("no pipeline database" in note for note in report.notes)
 
 
-def test_the_audit_writes_nothing_to_the_data_root(healthy):
+def test_the_audit_writes_nothing_to_the_data_root(healthy, tmp_path):
     """The constraint the whole command exists under, measured end to end."""
 
     config, _ = healthy
     root = config.base_data_path
     before = _fingerprint(root)
 
-    assert main.run_audit_mode("config.yaml", []) == 0
+    assert main.run_audit_mode(_config_file(tmp_path), []) == 0
 
     assert _fingerprint(root) == before
 
 
-def test_the_command_separates_a_broken_database_from_broken_data(healthy):
+def test_the_command_separates_a_broken_database_from_broken_data(
+    healthy, tmp_path
+):
     config, published = healthy
-    assert main.run_audit_mode("config.yaml", ["NSE_FO"]) == 0
+    config_file = _config_file(tmp_path)
+    assert main.run_audit_mode(config_file, ["NSE_FO"]) == 0
 
     published.write_text("SYMBOL,9,9,9\n", encoding="utf-8")
-    assert main.run_audit_mode("config.yaml", ["NSE_FO"]) == 1
+    assert main.run_audit_mode(config_file, ["NSE_FO"]) == 1
 
     database = config.base_data_path / ".state" / "pipeline_state.sqlite3"
     database.write_bytes(b"not a database")
-    assert main.run_audit_mode("config.yaml", []) == 2
+    assert main.run_audit_mode(config_file, []) == 2
 
 
 def test_the_parser_distinguishes_no_audit_from_a_whole_root_audit():
@@ -356,7 +403,7 @@ def test_a_record_that_cannot_be_parsed_is_reported_not_quarantined(healthy):
 
 
 def test_a_complete_stage_with_no_digest_is_a_finding_in_itself(tmp_path):
-    config = Config("config.yaml")
+    config = _config()
     published = _publish(config, "FO", DAY, "SYMBOL,1,2,3\n")
 
     manifest = PipelineManifest(config.base_data_path)
@@ -367,6 +414,8 @@ def test_a_complete_stage_with_no_digest_is_a_finding_in_itself(tmp_path):
         ("downloaded", "validated", "daily"),
         ("delivery", "symbols", "actions", "combined"),
     )
+    manifest.mark("NSE", "FO", DAY, "downloaded", "complete")
+    manifest.mark("NSE", "FO", DAY, "validated", "complete", rows=1)
     manifest.mark(
         "NSE", "FO", DAY, "daily", "complete", path=str(published), rows=1
     )
@@ -382,7 +431,7 @@ def test_a_complete_stage_with_no_digest_is_a_finding_in_itself(tmp_path):
 def test_a_data_root_that_moved_is_matched_by_layout_not_by_path(tmp_path):
     # Recorded paths are absolute and were written wherever the data root was
     # at the time.  A restored backup must not report every file as missing.
-    config = Config("config.yaml")
+    config = _config()
     published = _publish(config, "FO", DAY, "SYMBOL,1,2,3\n")
     elsewhere = Path("/somewhere/else/NSE_BSE_Data/NSE/FO") / published.name
 
@@ -394,6 +443,8 @@ def test_a_data_root_that_moved_is_matched_by_layout_not_by_path(tmp_path):
         ("downloaded", "validated", "daily"),
         ("delivery", "symbols", "actions", "combined"),
     )
+    manifest.mark("NSE", "FO", DAY, "downloaded", "complete")
+    manifest.mark("NSE", "FO", DAY, "validated", "complete", rows=1)
     manifest.mark(
         "NSE",
         "FO",
@@ -443,7 +494,7 @@ def test_a_running_download_is_flagged_as_making_findings_transient(healthy):
 
 
 def test_a_complete_stage_with_no_path_is_a_finding_in_itself(tmp_path):
-    config = Config("config.yaml")
+    config = _config()
 
     manifest = PipelineManifest(config.base_data_path)
     manifest.begin(
@@ -453,6 +504,8 @@ def test_a_complete_stage_with_no_path_is_a_finding_in_itself(tmp_path):
         ("downloaded", "validated", "daily"),
         ("delivery", "symbols", "actions", "combined"),
     )
+    manifest.mark("NSE", "FO", DAY, "downloaded", "complete")
+    manifest.mark("NSE", "FO", DAY, "validated", "complete", rows=1)
     manifest.mark(
         "NSE", "FO", DAY, "daily", "complete", component_sha256="a" * 64
     )
@@ -527,3 +580,143 @@ def test_records_for_a_segment_this_version_does_not_publish_are_noted(healthy):
     ]
     assert len(unknown) == 1
     assert not report.failed
+
+
+def _categories(report, category: str) -> list:
+    return [
+        finding for finding in report.findings if finding.category == category
+    ]
+
+
+def test_a_truncated_head_is_reported_against_the_configured_start(tmp_path):
+    # The defect this replaces: `get_missing_file_dates` looks only between
+    # the first and last filename, so a database that never went back far
+    # enough looks complete to it.
+    config = _config(date(2026, 7, 27))
+    published = _publish(config, "FO", DAY, "SYMBOL,1,2,3\n")
+    _record_simple(config.base_data_path, "FO", DAY, published)
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    head = _categories(report, "head-gap")
+    assert len(head) == 1
+    assert "2026-07-27 to 2026-07-29" in head[0].message
+    assert report.failed
+
+
+def test_a_stale_tail_is_visible_without_failing_the_audit(
+    monkeypatch, tmp_path
+):
+    config = _config()
+    published = _publish(config, "FO", DAY, "SYMBOL,1,2,3\n")
+    _record_simple(config.base_data_path, "FO", DAY, published)
+    _pin_clock(monkeypatch, date(2026, 8, 7))
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    tail = _categories(report, "stale-tail")
+    assert len(tail) == 1
+    # Freshness is the owner's business; only damage fails the command.
+    assert tail[0].severity == "notice"
+    assert "2026-07-31 to 2026-08-07" in tail[0].message
+    assert not report.failed
+
+
+def test_a_missing_day_inside_the_published_range_is_reported(tmp_path):
+    config = _config(date(2026, 7, 28))
+    for day in (date(2026, 7, 28), DAY):
+        published = _publish(config, "FO", day, "SYMBOL,1,2,3\n")
+        _record_simple(config.base_data_path, "FO", day, published)
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    missing = _categories(report, "missing-dates")
+    assert len(missing) == 1
+    assert "2026-07-29" in missing[0].message
+    assert report.failed
+
+
+def test_a_holiday_is_not_mistaken_for_a_missing_day(monkeypatch, tmp_path):
+    # 26 June 2026 is a trading holiday in the bundled calendar, with a
+    # weekend behind it.  Judging the gap without a calendar would invent
+    # three missing sessions here.
+    _pin_clock(monkeypatch, date(2026, 6, 29))
+    config = _config(date(2026, 6, 25))
+    for day in (date(2026, 6, 25), date(2026, 6, 29)):
+        published = _publish(config, "FO", day, "SYMBOL,1,2,3\n")
+        _record_simple(config.base_data_path, "FO", day, published)
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert report.findings == ()
+
+
+def test_a_date_the_exchange_never_published_is_not_a_gap(tmp_path):
+    config = _config(date(2026, 7, 28))
+    for day in (date(2026, 7, 28), DAY):
+        published = _publish(config, "FO", day, "SYMBOL,1,2,3\n")
+        _record_simple(config.base_data_path, "FO", day, published)
+    PipelineManifest(config.base_data_path).skip_date(
+        "NSE", "FO", date(2026, 7, 29), "The exchange published no report"
+    )
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert _categories(report, "missing-dates") == []
+    assert not report.failed
+
+
+def test_a_year_with_no_trading_calendar_is_declined_not_guessed(
+    monkeypatch, tmp_path
+):
+    # The bundled calendar starts in 2013.  Treating an unknown year as
+    # holiday-free would report every Diwali in it as a missing session.
+    _pin_clock(monkeypatch, date(2005, 6, 30))
+    config = _config(date(2005, 6, 1))
+    published = _publish(config, "FO", date(2005, 6, 30), "SYMBOL,1,2,3\n")
+    _record_simple(config.base_data_path, "FO", date(2005, 6, 30), published)
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert _categories(report, "missing-dates") == []
+    assert _categories(report, "head-gap") == []
+    assert any("no trading calendar is known for 2005" in note
+               for note in report.notes)
+
+
+def test_a_truncated_day_is_caught_by_neighbours_when_no_digest_can_be(
+    tmp_path,
+):
+    """The only plausibility check data written before the manifest can get."""
+
+    config = _config(date(2026, 7, 21))
+    days = [
+        date(2026, 7, day) for day in (21, 22, 23, 24, 27, 28, 29, 30)
+    ]
+    for day in days:
+        rows = 5 if day == date(2026, 7, 28) else 100
+        _publish(config, "FO", day, "SYMBOL,1,2,3\n" * rows)
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    outliers = _categories(report, "row-count-outlier")
+    assert len(outliers) == 1
+    assert outliers[0].target_date == date(2026, 7, 28)
+    assert "5 rows is 5% of the 100-row median" in outliers[0].message
+
+
+def test_a_file_that_gained_rows_since_publication_says_how(healthy):
+    config, published = healthy
+
+    published.write_text(
+        "SYMBOL,1,2,3\nSYMBOL,4,5,6\n", encoding="utf-8"
+    )
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert {finding.category for finding in report.findings} == {
+        "digest-mismatch",
+        "row-count-drift",
+    }
+    drift = _categories(report, "row-count-drift")[0]
+    assert "holds 2 rows but the pipeline recorded 1" in drift.message

--- a/tests/test_audit_command.py
+++ b/tests/test_audit_command.py
@@ -981,3 +981,44 @@ def test_a_registry_naming_a_file_that_does_not_exist_is_reported(
     missing = _categories(report, "missing-registered-file")
     assert len(missing) == 1
     assert "gone.txt" in missing[0].message
+
+
+def test_two_files_claiming_one_date_are_reported(healthy):
+    config, published = healthy
+    published.with_suffix(".csv").write_text("SYMBOL,1,2,3\n", encoding="utf-8")
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    duplicates = _categories(report, "duplicate-published-file")
+    assert len(duplicates) == 1
+    assert duplicates[0].target_date == DAY
+
+
+def test_auditing_a_segment_that_feeds_no_history_skips_the_symbol_check(
+    symbols_root,
+):
+    # Someone asking about NSE futures did not ask about symbol histories,
+    # and reading 8,000 of them to answer would be its own kind of wrong.
+    _write_history(symbols_root, "NSE", "ghost.txt", [EARLIER])
+
+    futures = DatabaseAudit(symbols_root, ["NSE_FO"]).run()
+    equity = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    assert futures.symbols == ()
+    assert _categories(futures, "unaccounted-symbol-file") == []
+    assert len(_categories(equity, "unaccounted-symbol-file")) == 1
+
+
+def test_the_symbol_check_uses_every_snapshot_the_exchange_has(symbols_root):
+    """EQ and SME share one SYMBOLS folder, so half the snapshots is wrong."""
+
+    sme_day = DAY
+    _write_snapshot(
+        symbols_root, "NSE", "SME", sme_day, [("TINY", "INE000C01003", "3")]
+    )
+    _write_history(symbols_root, "NSE", "tiny.txt", [sme_day])
+
+    report = DatabaseAudit(symbols_root, ["NSE_EQ"]).run()
+
+    assert _categories(report, "unaccounted-symbol-file") == []
+    assert report.symbols[0].snapshots == 3

--- a/tests/test_audit_command.py
+++ b/tests/test_audit_command.py
@@ -1,0 +1,529 @@
+"""The read-only audit: what it verifies, and that it verifies it read-only.
+
+`--audit` exists because every sha256 written into the pipeline manifest used
+to be write-only.  Its one hard constraint is that answering "can I trust this
+database?" must not change the database, so the last test here fingerprints the
+whole data root around a full run.  That test is not decoration: it is what
+caught SQLite's own `mode=ro` rewriting `pipeline_state.sqlite3-shm`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+import main
+from src.core.config import Config
+from src.services.audit_service import AuditError, DatabaseAudit
+from src.services.pipeline_state import PipelineManifest
+
+DAY = date(2026, 7, 30)
+EARLIER = date(2026, 7, 29)
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _fingerprint(root: Path) -> tuple[tuple[str, int, int, str], ...]:
+    """Path, mtime, size and content digest of everything under ``root``."""
+
+    entries = []
+    for path in sorted(root.rglob("*")):
+        stat = path.stat()
+        content = _digest(path) if path.is_file() else ""
+        entries.append((str(path), stat.st_mtime_ns, stat.st_size, content))
+    return tuple(entries)
+
+
+def _publish(config: Config, segment: str, target_date: date, body: str) -> Path:
+    """Write one published file the way a completed download leaves it."""
+
+    folder = config.get_data_path("NSE", segment)
+    path = folder / f"{target_date.isoformat()}-NSE-{segment}.txt"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _record_simple(base: Path, segment: str, target_date: date, path: Path):
+    """Record one date whose published file carries its own digest."""
+
+    manifest = PipelineManifest(base)
+    manifest.begin(
+        "NSE",
+        segment,
+        target_date,
+        ("downloaded", "validated", "daily"),
+        ("delivery", "symbols", "actions", "combined"),
+    )
+    manifest.mark("NSE", segment, target_date, "downloaded", "complete")
+    manifest.mark("NSE", segment, target_date, "validated", "complete", rows=1)
+    manifest.mark(
+        "NSE",
+        segment,
+        target_date,
+        "daily",
+        "complete",
+        path=str(path),
+        sha256=_digest(path),
+        rows=1,
+    )
+    return manifest
+
+
+@pytest.fixture
+def healthy(tmp_path):
+    """A data root holding one recorded, verifiable NSE_FO date."""
+
+    config = Config("config.yaml")
+    published = _publish(config, "FO", DAY, "SYMBOL,1,2,3\n")
+    _record_simple(config.base_data_path, "FO", DAY, published)
+    return config, published
+
+
+def test_a_healthy_segment_verifies_and_reports_nothing(healthy):
+    config, _ = healthy
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert report.findings == ()
+    assert not report.failed
+    assert report.summaries[0].records == 1
+    assert report.summaries[0].files == 1
+    assert report.summaries[0].digests_verified == 1
+    assert "No problems found." in report.render()
+
+
+def test_a_rewritten_file_is_caught_by_its_recorded_digest(healthy):
+    config, published = healthy
+
+    published.write_text("SYMBOL,9,9,9\n", encoding="utf-8")
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert [finding.category for finding in report.findings] == [
+        "digest-mismatch"
+    ]
+    assert report.findings[0].severity == "error"
+    assert report.findings[0].target_date == DAY
+    assert report.failed
+
+
+def test_a_deleted_file_is_caught_even_though_the_record_survives(healthy):
+    config, published = healthy
+
+    published.unlink()
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert [finding.category for finding in report.findings] == ["missing-file"]
+    assert report.summaries[0].digests_verified == 0
+    assert report.failed
+
+
+def test_a_file_no_record_vouches_for_is_reported(healthy):
+    config, _ = healthy
+
+    _publish(config, "FO", date(2026, 7, 31), "SYMBOL,1,2,3\n")
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert [finding.category for finding in report.findings] == [
+        "unrecorded-file"
+    ]
+    assert report.findings[0].severity == "warning"
+    assert report.findings[0].target_date == date(2026, 7, 31)
+
+
+def test_data_older_than_the_manifest_is_a_notice_rather_than_a_failure(
+    healthy,
+):
+    # A user upgrading from v1.0.1 has years of files predating the manifest.
+    # Nothing can vouch for them, but they are not evidence of damage.
+    config, _ = healthy
+
+    _publish(config, "FO", EARLIER, "SYMBOL,1,2,3\n")
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert [finding.severity for finding in report.findings] == ["notice"]
+    assert report.findings[0].category == "unrecorded-file"
+    assert not report.failed
+
+
+def test_a_leftover_temporary_file_shows_an_interrupted_write(healthy):
+    config, published = healthy
+
+    (published.parent / f"{published.name}.tmp").write_text(
+        "half", encoding="utf-8"
+    )
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert [finding.category for finding in report.findings] == [
+        "interrupted-write"
+    ]
+    assert report.failed
+
+
+def _record_deferred(config: Config, component: Path, published: Path) -> None:
+    """Record an EQ date published by the combined stage, as NSE EQ is."""
+
+    manifest = PipelineManifest(config.base_data_path)
+    manifest.begin(
+        "NSE",
+        "EQ",
+        DAY,
+        ("downloaded", "validated", "daily", "combined"),
+        ("delivery", "symbols", "actions"),
+    )
+    manifest.mark("NSE", "EQ", DAY, "downloaded", "complete")
+    manifest.mark("NSE", "EQ", DAY, "validated", "complete", rows=1)
+    manifest.mark(
+        "NSE",
+        "EQ",
+        DAY,
+        "daily",
+        "complete",
+        path=str(published),
+        # Deferred publication records the *component's* digest here.
+        sha256=_digest(component),
+        component_path=str(component),
+        component_sha256=_digest(component),
+        publication_deferred=True,
+        rows=1,
+    )
+    manifest.mark(
+        "NSE",
+        "EQ",
+        DAY,
+        "combined",
+        "complete",
+        path=str(published),
+        sha256=_digest(published),
+        rows=3,
+        components=["EQ", "SME", "INDEX"],
+    )
+
+
+@pytest.fixture
+def deferred(tmp_path):
+    """An NSE EQ date whose published file legitimately outgrew its component.
+
+    The daily stage stores the component digest under ``sha256`` and the
+    combined stage appends SME and Index rows afterwards.  Comparing the daily
+    digest against the file on disk would report every such date as corrupt,
+    which is the false positive this fixture exists to pin down.
+    """
+
+    config = Config("config.yaml")
+    component_dir = config.base_data_path / ".state" / "components" / "NSE" / "EQ"
+    component_dir.mkdir(parents=True)
+    component = component_dir / f"{DAY.isoformat()}.csv"
+    component.write_text("EQ\n", encoding="utf-8")
+
+    published = _publish(config, "EQ", DAY, "EQ\nSME\nINDEX\n")
+    _record_deferred(config, component, published)
+    return config, component, published
+
+
+def test_an_appended_combined_file_is_verified_not_rejected(deferred):
+    config, _, _ = deferred
+
+    report = DatabaseAudit(config, ["NSE_EQ"]).run()
+
+    assert report.findings == ()
+    # The component and the combined file, each against its own digest.
+    assert report.summaries[0].digests_verified == 2
+
+
+def test_corrupting_the_combined_file_is_still_caught(deferred):
+    config, _, published = deferred
+
+    published.write_text("EQ\nSME\nTAMPERED\n", encoding="utf-8")
+
+    report = DatabaseAudit(config, ["NSE_EQ"]).run()
+
+    assert [finding.category for finding in report.findings] == [
+        "digest-mismatch"
+    ]
+    assert "combined file" in report.findings[0].message
+
+
+def test_a_date_that_never_reached_publication_is_reported(deferred):
+    config, component, published = deferred
+    published.unlink()
+
+    manifest = PipelineManifest(config.base_data_path)
+    manifest.mark("NSE", "EQ", DAY, "combined", "failed", error="interrupted")
+
+    report = DatabaseAudit(config, ["NSE_EQ"]).run()
+
+    assert [finding.category for finding in report.findings] == [
+        "unpublished-date"
+    ]
+    assert report.failed
+
+
+def test_an_unknown_segment_is_refused_before_anything_is_read(tmp_path):
+    config = Config("config.yaml")
+
+    with pytest.raises(AuditError) as error:
+        DatabaseAudit(config, ["NSE_COMMODITY"])
+
+    assert "NSE_COMMODITY" in str(error.value)
+
+
+def test_a_root_with_no_pipeline_database_says_so(tmp_path):
+    config = Config("config.yaml")
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert report.findings == ()
+    assert any("no pipeline database" in note for note in report.notes)
+
+
+def test_the_audit_writes_nothing_to_the_data_root(healthy):
+    """The constraint the whole command exists under, measured end to end."""
+
+    config, _ = healthy
+    root = config.base_data_path
+    before = _fingerprint(root)
+
+    assert main.run_audit_mode("config.yaml", []) == 0
+
+    assert _fingerprint(root) == before
+
+
+def test_the_command_separates_a_broken_database_from_broken_data(healthy):
+    config, published = healthy
+    assert main.run_audit_mode("config.yaml", ["NSE_FO"]) == 0
+
+    published.write_text("SYMBOL,9,9,9\n", encoding="utf-8")
+    assert main.run_audit_mode("config.yaml", ["NSE_FO"]) == 1
+
+    database = config.base_data_path / ".state" / "pipeline_state.sqlite3"
+    database.write_bytes(b"not a database")
+    assert main.run_audit_mode("config.yaml", []) == 2
+
+
+def test_the_parser_distinguishes_no_audit_from_a_whole_root_audit():
+    parser = main.setup_argument_parser()
+
+    assert parser.parse_args([]).audit is None
+    assert parser.parse_args(["--audit"]).audit == []
+    assert parser.parse_args(["--audit", "NSE_EQ", "BSE_EQ"]).audit == [
+        "NSE_EQ",
+        "BSE_EQ",
+    ]
+
+
+def test_a_record_that_cannot_be_parsed_is_reported_not_quarantined(healthy):
+    # The ordinary state readers copy anything they cannot parse into
+    # `.state/quarantine`.  That is a write, so the audit reports instead.
+    import sqlite3
+
+    config, _ = healthy
+    database = config.base_data_path / ".state" / "pipeline_state.sqlite3"
+    connection = sqlite3.connect(database)
+    connection.execute(
+        "INSERT INTO pipeline_dates(record_key, exchange, segment, "
+        "target_date, complete, skipped_reason, updated_at, record_json) "
+        "VALUES (?,?,?,?,?,?,?,?)",
+        (
+            "NSE_FO:2026-07-28",
+            "NSE",
+            "FO",
+            "2026-07-28",
+            0,
+            None,
+            "2026-07-28T00:00:00+00:00",
+            "{ this is not json",
+        ),
+    )
+    connection.commit()
+    connection.close()
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert [finding.category for finding in report.findings] == [
+        "unreadable-record"
+    ]
+    assert not (config.base_data_path / ".state" / "quarantine").exists()
+
+
+def test_a_complete_stage_with_no_digest_is_a_finding_in_itself(tmp_path):
+    config = Config("config.yaml")
+    published = _publish(config, "FO", DAY, "SYMBOL,1,2,3\n")
+
+    manifest = PipelineManifest(config.base_data_path)
+    manifest.begin(
+        "NSE",
+        "FO",
+        DAY,
+        ("downloaded", "validated", "daily"),
+        ("delivery", "symbols", "actions", "combined"),
+    )
+    manifest.mark(
+        "NSE", "FO", DAY, "daily", "complete", path=str(published), rows=1
+    )
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert [finding.category for finding in report.findings] == [
+        "incomplete-record"
+    ]
+    assert "no usable sha256" in report.findings[0].message
+
+
+def test_a_data_root_that_moved_is_matched_by_layout_not_by_path(tmp_path):
+    # Recorded paths are absolute and were written wherever the data root was
+    # at the time.  A restored backup must not report every file as missing.
+    config = Config("config.yaml")
+    published = _publish(config, "FO", DAY, "SYMBOL,1,2,3\n")
+    elsewhere = Path("/somewhere/else/NSE_BSE_Data/NSE/FO") / published.name
+
+    manifest = PipelineManifest(config.base_data_path)
+    manifest.begin(
+        "NSE",
+        "FO",
+        DAY,
+        ("downloaded", "validated", "daily"),
+        ("delivery", "symbols", "actions", "combined"),
+    )
+    manifest.mark(
+        "NSE",
+        "FO",
+        DAY,
+        "daily",
+        "complete",
+        path=str(elsewhere),
+        sha256=_digest(published),
+        rows=1,
+    )
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert report.findings == ()
+    assert report.summaries[0].digests_verified == 1
+    assert any("different path" in note for note in report.notes)
+
+
+def test_a_file_outside_the_naming_contract_is_noted(healthy):
+    config, published = healthy
+    (published.parent / "notes.txt").write_text("mine", encoding="utf-8")
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert [finding.category for finding in report.findings] == [
+        "unrecognised-file"
+    ]
+    assert not report.failed
+
+
+def test_a_running_download_is_flagged_as_making_findings_transient(healthy):
+    import json
+    import os
+    import socket
+
+    config, _ = healthy
+    lock = config.base_data_path / ".state" / "app.lock"
+    lock.write_text(
+        json.dumps({"pid": os.getpid(), "host": socket.gethostname()}),
+        encoding="utf-8",
+    )
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert any("holds the data-root lock" in note for note in report.notes)
+    assert "Note: another copy of the application" in report.render()
+
+
+def test_a_complete_stage_with_no_path_is_a_finding_in_itself(tmp_path):
+    config = Config("config.yaml")
+
+    manifest = PipelineManifest(config.base_data_path)
+    manifest.begin(
+        "NSE",
+        "FO",
+        DAY,
+        ("downloaded", "validated", "daily"),
+        ("delivery", "symbols", "actions", "combined"),
+    )
+    manifest.mark(
+        "NSE", "FO", DAY, "daily", "complete", component_sha256="a" * 64
+    )
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    # One for the component the record half-describes, one for the published
+    # file it claims to have written: neither can be checked against anything.
+    assert {finding.category for finding in report.findings} == {
+        "incomplete-record"
+    }
+    assert [
+        finding.message for finding in report.findings
+    ] == [
+        "the reconciliation component is recorded complete but with no path",
+        "the published file is recorded complete but with no path",
+    ]
+
+
+def test_a_filename_carrying_an_impossible_date_is_reported(healthy):
+    config, published = healthy
+    (published.parent / "2026-02-30-NSE-FO.txt").write_text(
+        "x", encoding="utf-8"
+    )
+
+    report = DatabaseAudit(config, ["NSE_FO"]).run()
+
+    assert [finding.category for finding in report.findings] == [
+        "unrecognised-file"
+    ]
+    assert report.findings[0].severity == "warning"
+
+
+def test_records_for_a_segment_this_version_does_not_publish_are_noted(healthy):
+    import json
+    import sqlite3
+
+    config, _ = healthy
+    record = {
+        "exchange": "NSE",
+        "segment": "COMMODITY",
+        "date": DAY.isoformat(),
+        "required_stages": ["downloaded"],
+        "stages": {"downloaded": {"status": "complete"}},
+        "complete": True,
+    }
+    database = config.base_data_path / ".state" / "pipeline_state.sqlite3"
+    connection = sqlite3.connect(database)
+    connection.execute(
+        "INSERT INTO pipeline_dates(record_key, exchange, segment, "
+        "target_date, complete, skipped_reason, updated_at, record_json) "
+        "VALUES (?,?,?,?,?,?,?,?)",
+        (
+            f"NSE_COMMODITY:{DAY.isoformat()}",
+            "NSE",
+            "COMMODITY",
+            DAY.isoformat(),
+            1,
+            None,
+            "2026-07-30T00:00:00+00:00",
+            json.dumps(record),
+        ),
+    )
+    connection.commit()
+    connection.close()
+
+    report = DatabaseAudit(config).run()
+
+    unknown = [
+        finding for finding in report.findings
+        if finding.category == "unknown-segment"
+    ]
+    assert len(unknown) == 1
+    assert not report.failed


### PR DESCRIPTION
Closes section 4.1 of `docs/engineering/CODE_DEFECT_REMEDIATION_PLAN.md`.

Every sha256 written into the pipeline manifest was write-only: nothing ever read one back. `get_missing_file_dates` looks only *between* the first and last filename on disk, so a truncated head and a stale tail were both invisible. Nothing enumerated `<EX>/SYMBOLS/` at all. The only repair tooling was the destructive `--rebuild-*`.

`python main.py --audit [EXCHANGE_SEGMENT ...]` answers "is this database complete and self-consistent?" and writes nothing.

## What it checks

- Every recorded digest against disk: published files, reconciliation components, combined outputs, and the `.state/raw` snapshots against their own metadata.
- Coverage from `base_start_date` to the last session the exchanges published, so head gaps and stale tails are both visible. Holidays come from the offline calendar; a year neither the cache nor the bundle covers is declined rather than guessed.
- Row counts against what was recorded, and against neighbouring sessions — the only plausibility check available for files written before the manifest existed.
- Every `SYMBOLS/*.txt` history reconciled against the raw snapshots, in both directions.
- Orphans: components and snapshots for unpublished dates, metadata without its snapshot, leftover temporary files, registry entries naming files that do not exist, duplicate dates in a history, two files claiming one date.

Exit codes are three-valued: `0` clean, `1` findings, `2` the audit could not look. A script treating the last two alike would report a broken audit as clean data. Notices — data older than the manifest, an undownloaded tail, the pre-ISIN column set — do not fail the command.

## Read-only had to be built, not merely intended

Four ordinary routes into a data root write before they read, so none is used here: `Config.get_data_path` creates the folder it is asked about (`resolve_data_path` was split out), `DataManager.__init__` creates the whole folder structure (the filename contract moved to `DAILY_FILE_PATTERNS`), `PipelineManifest` initialises its SQLite schema and imports the legacy JSON in its constructor, and `VersionedJSONStore.read` quarantines what it cannot parse.

**SQLite's own `mode=ro` is not read-only either.** Opening the real data root that way left `pipeline_state.sqlite3-shm` rewritten: a WAL database needs its shared-memory index, and a read-only *connection* still creates and stamps it. On a read-only medium it would fail outright. The database is copied to a temporary directory outside the data root and the copy is opened. A test fingerprints every path, mtime, size and content digest under a data root around a full run; reverting that change fails it.

## The false positive that would have made it useless

For NSE EQ the daily stage records the *component's* digest under `sha256`, and the combined stage appends SME and Index rows to the published file afterwards with its own digest. Comparing the daily digest against that file would report every combined date as corrupt. Each is checked against its own digest; both halves are pinned by tests.

## Measured on the maintainer's real data root

8,615 entries: 308 recorded digests and 84 raw snapshots verified, 8,096 symbol histories reconciled across 208,555 (symbol, date) pairs, 12 true findings (six head gaps of 234 trading days, six stale tails of 8 sessions), 2.8 seconds, tree byte-for-byte and stat-for-stat unchanged.

## Gates

469 tests pass on Python 3.10 and 3.13; coverage 78.3% overall and 88% on the new module; ruff and mypy clean; `--smoke-gui` exits 0.

No version bump: `version.py` is deliberately untouched, so this does not notify installed clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)